### PR TITLE
Release VS Code extension 1.8.0

### DIFF
--- a/scripts/release-client.sh
+++ b/scripts/release-client.sh
@@ -2,8 +2,16 @@
 
 set -euo pipefail
 
+source ./scripts/tag-release.inc
+
+version=$(cat vscode-client/package.json | jq -r .version)
+tag="vscode-client-${version}"
+
 yarn run clean
 yarn install
 yarn run verify:bail
 
-cd vscode-client && npx vsce publish -p $VSCE_TOKEN || echo 'Deploy failed'
+cd vscode-client
+
+# NOTE: it would be much nicer if we could detect which version was deployed...
+npx vsce publish -p $VSCE_TOKEN && tagRelease $tag || echo 'Deploy failed, probably there was no changes'

--- a/scripts/release-server.sh
+++ b/scripts/release-server.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+source ./scripts/tag-release.inc
+
 version=$(cat server/package.json | jq -r .version)
 tag="server-${version}"
 
@@ -16,7 +18,6 @@ yarn run clean
 yarn install
 yarn run verify:bail
 
-git tag -a "${tag}" -m "Release ${version} of the bash-language-server package"
-git push origin "${tag}"
-
-cd server && npm publish
+cd server
+npm publish
+tagRelease $tag

--- a/scripts/tag-release.inc
+++ b/scripts/tag-release.inc
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function tagRelease {
+  tag=$1
+  git tag -a "${tag}" -m "Release ${tag}"
+  git push origin "${tag}"
+}

--- a/vscode-client/CHANGELOG.md
+++ b/vscode-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash IDE
 
+## 1.8.0
+
+* Upgrade LSP to 1.11.1 (support for workspace symbols). This can for example be used by doing `Command + P` and then write `# someSearchQuery`.
+
 ## 1.7.0
 
 * Upgrade LSP to 1.10.0 (improved completion handler)

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -4,7 +4,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "publisher": "mads-hartmann",
   "repository": {
     "type": "git",
@@ -57,7 +57,7 @@
     "postinstall": "vscode-install"
   },
   "dependencies": {
-    "bash-language-server": "1.10.0",
+    "bash-language-server": "1.11.1",
     "vscode-languageclient": "^5.2.1",
     "vscode-languageserver": "^5.2.1"
   },

--- a/vscode-client/yarn.lock
+++ b/vscode-client/yarn.lock
@@ -82,11 +82,12 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-bash-language-server@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/bash-language-server/-/bash-language-server-1.10.0.tgz#2d0e79b4c4e2ecd509c9b96c2b289a84b5eb779d"
-  integrity sha512-G9SK2j6hVXexW66F7MTGZF3tk5g0A73KiHHH4nTON1KiqkSRiq0mNS5LNAzyXz9tbqihATQ9uPxbiuM/SjZkWA==
+bash-language-server@1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/bash-language-server/-/bash-language-server-1.11.1.tgz#a23cb42a2916a7cda342ef6b4a20aaaaf0f81dfb"
+  integrity sha512-1fF8RVa/y3yKvMAeorLbapFtRQx85c51V2P+P25U6Cl6HyDzh1IezgmdW6Rau4jg2hDWVN1hCpce36UGjCGE2g==
   dependencies:
+    fuzzy-search "^3.2.1"
     glob "^7.1.6"
     request "^2.83.0"
     request-promise-native "^1.0.5"
@@ -295,6 +296,11 @@ form-data@~2.3.2:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fuzzy-search@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.2.1.tgz#65d5faad6bc633aee86f1898b7788dfe312ac6c9"
+  integrity sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg==
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
Release VS Code extension 1.8.0 with the new workspace symbol support. 

Behind the scenes: I've added git tags for the client now. And when doing so I have a **feature request to bash-ide: auto completion when writing `source`** :)