### PR TITLE
Completion improvements: workspace symbols & executables

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 1.12.0
+
+* Completion handler improvements: remove duplicates, include symbols from other files, ensure that programs found on the paths are actually executable (https://github.com/bash-lsp/bash-language-server/pull/215)
+
 ## 1.11.3
 
 * Recover from file reading errors (https://github.com/bash-lsp/bash-language-server/pull/211)

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/bash-lsp/bash-language-server"
   },
   "engines": {
-    "node" : ">=8.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "fuzzy-search": "^3.2.1",

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -126,140 +126,7 @@ Array [
 ]
 `;
 
-exports[`findSymbolCompletions return a list of symbols 1`] = `
-Array [
-  Object {
-    "data": Object {
-      "name": "ret",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "ret",
-  },
-  Object {
-    "data": Object {
-      "name": "configures",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "configures",
-  },
-  Object {
-    "data": Object {
-      "name": "npm_config_loglevel",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "npm_config_loglevel",
-  },
-  Object {
-    "data": Object {
-      "name": "node",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "node",
-  },
-  Object {
-    "data": Object {
-      "name": "TMP",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "TMP",
-  },
-  Object {
-    "data": Object {
-      "name": "BACK",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "BACK",
-  },
-  Object {
-    "data": Object {
-      "name": "tar",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "tar",
-  },
-  Object {
-    "data": Object {
-      "name": "MAKE",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "MAKE",
-  },
-  Object {
-    "data": Object {
-      "name": "make",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "make",
-  },
-  Object {
-    "data": Object {
-      "name": "clean",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "clean",
-  },
-  Object {
-    "data": Object {
-      "name": "node_version",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "node_version",
-  },
-  Object {
-    "data": Object {
-      "name": "t",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "t",
-  },
-  Object {
-    "data": Object {
-      "name": "url",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "url",
-  },
-  Object {
-    "data": Object {
-      "name": "ver",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "ver",
-  },
-  Object {
-    "data": Object {
-      "name": "isnpm10",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "isnpm10",
-  },
-  Object {
-    "data": Object {
-      "name": "NODE",
-      "type": 3,
-    },
-    "kind": 6,
-    "label": "NODE",
-  },
-]
-`;
-
-exports[`findSymbols issue 101 1`] = `
+exports[`findSymbolsForFile issue 101 1`] = `
 Array [
   Object {
     "kind": 12,
@@ -335,7 +202,7 @@ Array [
 ]
 `;
 
-exports[`findSymbols returns a list of SymbolInformation if uri is found 1`] = `
+exports[`findSymbolsForFile returns a list of SymbolInformation if uri is found 1`] = `
 Array [
   Object {
     "kind": 13,

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -61,23 +61,23 @@ describe('findReferences', () => {
   })
 })
 
-describe('findSymbols', () => {
+describe('findSymbolsForFile', () => {
   it('returns empty list if uri is not found', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
-    const result = analyzer.findSymbols('foobar.sh')
+    const result = analyzer.findSymbolsForFile({ uri: 'foobar.sh' })
     expect(result).toEqual([])
   })
 
   it('returns a list of SymbolInformation if uri is found', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
-    const result = analyzer.findSymbols(CURRENT_URI)
+    const result = analyzer.findSymbolsForFile({ uri: CURRENT_URI })
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
 
   it('issue 101', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.ISSUE101)
-    const result = analyzer.findSymbols(CURRENT_URI)
+    const result = analyzer.findSymbolsForFile({ uri: CURRENT_URI })
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
@@ -102,9 +102,91 @@ describe('wordAtPoint', () => {
 })
 
 describe('findSymbolCompletions', () => {
-  it('return a list of symbols', () => {
-    analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
-    expect(analyzer.findSymbolCompletions(CURRENT_URI)).toMatchSnapshot()
+  it('return a list of symbols across the workspace', () => {
+    analyzer.analyze('install.sh', FIXTURES.INSTALL)
+    analyzer.analyze('sourcing-sh', FIXTURES.SOURCING)
+
+    expect(analyzer.findSymbolsMatchingWord({ word: 'npm_config_logl' }))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 27,
+                "line": 40,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 40,
+              },
+            },
+            "uri": "dummy-uri.sh",
+          },
+          "name": "npm_config_loglevel",
+        },
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 31,
+                "line": 48,
+              },
+              "start": Object {
+                "character": 2,
+                "line": 48,
+              },
+            },
+            "uri": "dummy-uri.sh",
+          },
+          "name": "npm_config_loglevel",
+        },
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 27,
+                "line": 40,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 40,
+              },
+            },
+            "uri": "install.sh",
+          },
+          "name": "npm_config_loglevel",
+        },
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 31,
+                "line": 48,
+              },
+              "start": Object {
+                "character": 2,
+                "line": 48,
+              },
+            },
+            "uri": "install.sh",
+          },
+          "name": "npm_config_loglevel",
+        },
+      ]
+    `)
+
+    expect(analyzer.findSymbolsMatchingWord({ word: 'xxxxxxxx' })).toMatchInlineSnapshot(
+      `Array []`,
+    )
+
+    expect(analyzer.findSymbolsMatchingWord({ word: 'BLU' })).toMatchInlineSnapshot(
+      `Array []`,
+    )
   })
 })
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -177,6 +177,8 @@ export default class BashServer {
       }))
     }
 
+    // FIXME: could also be a symbol
+
     return null
   }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -234,16 +234,19 @@ export default class BashServer {
       },
     }))
 
-    const programCompletions = this.executables.list().map((s: string) => {
-      return {
-        label: s,
-        kind: LSP.SymbolKind.Function,
-        data: {
-          name: s,
-          type: CompletionItemDataType.Executable,
-        },
-      }
-    })
+    const programCompletions = this.executables
+      .list()
+      .filter(executable => !Builtins.isBuiltin(executable))
+      .map(executable => {
+        return {
+          label: executable,
+          kind: LSP.SymbolKind.Function,
+          data: {
+            name: executable,
+            type: CompletionItemDataType.Executable,
+          },
+        }
+      })
 
     const builtinsCompletions = Builtins.LIST.map(builtin => ({
       label: builtin,
@@ -254,7 +257,6 @@ export default class BashServer {
       },
     }))
 
-    // TODO: we have duplicates here (e.g. echo is both a builtin AND have a man page)
     const allCompletions = [
       ...reservedWordsCompletions,
       ...symbolCompletions,

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -1,18 +1,5 @@
-import * as Fs from 'fs'
 import * as glob from 'glob'
 import * as Os from 'os'
-
-export function getStats(path: string): Promise<Fs.Stats> {
-  return new Promise((resolve, reject) => {
-    Fs.lstat(path, (err, stat) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(stat)
-      }
-    })
-  })
-}
 
 // from https://github.com/sindresorhus/untildify/blob/f85a087418aeaa2beb56fe2684fe3b64fc8c588d/index.js#L11
 export function untildify(pathWithTilde: string): string {

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -14,18 +14,20 @@ function getDocument(uri: string) {
 }
 
 export const FIXTURE_URI = {
-  MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
+  INSTALL: `file://${path.join(FIXTURE_FOLDER, 'install.sh')}`,
   ISSUE101: `file://${path.join(FIXTURE_FOLDER, 'issue101.sh')}`,
   ISSUE206: `file://${path.join(FIXTURE_FOLDER, 'issue206.sh')}`,
-  INSTALL: `file://${path.join(FIXTURE_FOLDER, 'install.sh')}`,
+  MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
+  SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
 }
 
 export const FIXTURE_DOCUMENT = {
-  MISSING_NODE: getDocument(FIXTURE_URI.MISSING_NODE),
-  ISSUE101: getDocument(FIXTURE_URI.ISSUE101),
   INSTALL: getDocument(FIXTURE_URI.INSTALL),
+  ISSUE101: getDocument(FIXTURE_URI.ISSUE101),
+  MISSING_NODE: getDocument(FIXTURE_URI.MISSING_NODE),
   PARSE_PROBLEMS: getDocument(FIXTURE_URI.PARSE_PROBLEMS),
+  SOURCING: getDocument(FIXTURE_URI.SOURCING),
 }
 
 export default FIXTURE_DOCUMENT

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -3,3 +3,7 @@
 source ./extension.inc
 
 echo $RED 'Hello in red!'
+
+echo $BLU
+
+add_a_us

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -7,3 +7,7 @@ echo $RED 'Hello in red!'
 echo $BLU
 
 add_a_us
+
+BOLD=`tput bold` # redefined
+
+echo $BOL


### PR DESCRIPTION
Completion handler improvements:
- symbols from other files are now also used (both variables and functions for now – we could consider limiting this), but we prefer local symbols if we have duplicates
- symbol completions from other files utilize the documentation feature to show where the symbol comes from
- remove duplicated completions for executables and builtins (e.g. echo is both a builtin AND have a man page)
- ensure that executable programs on the paths are actually *executable* 