### PR TITLE
Extend executable docs by calling --help if man page fails

### DIFF
--- a/server/src/executables.ts
+++ b/server/src/executables.ts
@@ -44,14 +44,24 @@ export default class Executables {
   /**
    * Look up documentation for the given executable.
    *
-   * For now it simply tries to look up the MAN documentation.
+   * For now it simply tries to look up the MAN documentation or calls --help.
    */
-  public documentation(executable: string): Promise<string> {
-    return ShUtil.execShellScript(`man ${executable} | col -b`).then(doc => {
-      return !doc
-        ? Promise.resolve(`No MAN page for ${executable}`)
-        : Promise.resolve(doc)
-    })
+  public async documentation(executable: string): Promise<null | string> {
+    try {
+      const manResult = await ShUtil.execShellScript(`man ${executable} | col -b`)
+      if (manResult) {
+        return manResult
+      }
+
+      const helpResult = await ShUtil.execShellScript(`${executable} --help  | col -b`)
+      if (helpResult) {
+        return helpResult
+      }
+    } catch (error) {
+      // Ignore any script errors
+    }
+
+    return null
   }
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -172,9 +172,13 @@ export default class BashServer {
     }
 
     if (this.executables.isExecutableOnPATH(word)) {
-      return this.executables.documentation(word).then(doc => ({
-        contents: getMarkdownHoverItem(doc),
-      }))
+      const doc = await this.executables.documentation(word)
+
+      if (doc) {
+        return {
+          contents: getMarkdownHoverItem(doc),
+        }
+      }
     }
 
     return null


### PR DESCRIPTION
There might be a security risk here. 🤔 