### PR TITLE
Handle glob errors instead of crashing

### DIFF
--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -55,7 +55,14 @@ export default class Analyzer {
       const getTimePassed = (): string =>
         `${(Date.now() - lookupStartTime) / 1000} seconds`
 
-      const filePaths = await getFilePaths({ globPattern, rootPath })
+      let filePaths: string[] = []
+      try {
+        filePaths = await getFilePaths({ globPattern, rootPath })
+      } catch (error) {
+        connection.window.showWarningMessage(
+          `Failed to analyze bash files using the glob "${globPattern}". The experience will be degraded. Consider configuring the glob or fix any permission issues. Error: ${error.message}`,
+        )
+      }
 
       // TODO: we could load all files without extensions: globPattern: '**/[^.]'
 

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -62,7 +62,14 @@ export function getMockConnection(): jest.Mocked<lsp.Connection> {
     sendRequest: jest.fn(),
     telemetry: {} as any,
     tracer: {} as any,
-    window: {} as any,
+    window: {
+      attachWorkDoneProgress: jest.fn(),
+      connection: {} as any,
+      createWorkDoneProgress: jest.fn(),
+      showErrorMessage: jest.fn(),
+      showInformationMessage: jest.fn(),
+      showWarningMessage: jest.fn(),
+    },
     workspace: {} as any,
   }
 }


### PR DESCRIPTION
Previously, when we failed to resolve the glob for shell files we crashed. Instead, we should just show a warning – the server can still be useful.

https://github.com/bash-lsp/bash-language-server/issues/223
