### PR TITLE
Glob in non-strict mode

### DIFF
--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -60,7 +60,7 @@ export default class Analyzer {
         filePaths = await getFilePaths({ globPattern, rootPath })
       } catch (error) {
         connection.window.showWarningMessage(
-          `Failed to analyze bash files using the glob "${globPattern}". The experience will be degraded. Consider configuring the glob or fix any permission issues. Error: ${error.message}`,
+          `Failed to analyze bash files using the glob "${globPattern}". The experience will be degraded. Error: ${error.message}`,
         )
       }
 

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -17,15 +17,16 @@ export async function getFilePaths({
   rootPath: string
 }): Promise<string[]> {
   return new Promise((resolve, reject) => {
-    glob(globPattern, { cwd: rootPath, nodir: true, absolute: true }, function(
-      err,
-      files,
-    ) {
-      if (err) {
-        return reject(err)
-      }
+    glob(
+      globPattern,
+      { cwd: rootPath, nodir: true, absolute: true, strict: false },
+      function(err, files) {
+        if (err) {
+          return reject(err)
+        }
 
-      resolve(files)
-    })
+        resolve(files)
+      },
+    )
   })
 }


### PR DESCRIPTION
Run glob in non-strict mode to recover from errors (e.g. permission issues).

Originally, it looked like we were already running in non-strict mode. But the [documentation](https://github.com/isaacs/node-glob/#options) for node-glob could be made more clear (https://github.com/isaacs/node-glob/issues/298).

Related: https://github.com/bash-lsp/bash-language-server/pull/224 #223 https://github.com/isaacs/node-glob/pull/413