### PR TITLE
Support 0/1 as value for HIGHLIGHT_PARSING_ERRORS

### DIFF
--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -63,6 +63,18 @@ describe('highlightParsingError', () => {
     expect(result).toEqual(true)
 
     process.env = {
+      HIGHLIGHT_PARSING_ERRORS: '1',
+    }
+    result = config.getHighlightParsingError()
+    expect(result).toEqual(true)
+
+    process.env = {
+      HIGHLIGHT_PARSING_ERRORS: '0',
+    }
+    result = config.getHighlightParsingError()
+    expect(result).toEqual(false)
+
+    process.env = {
       HIGHLIGHT_PARSING_ERRORS: 'false',
     }
     result = config.getHighlightParsingError()

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -17,6 +17,6 @@ export function getGlobPattern(): string {
 export function getHighlightParsingError(): boolean {
   const { HIGHLIGHT_PARSING_ERRORS } = process.env
   return typeof HIGHLIGHT_PARSING_ERRORS !== 'undefined'
-    ? HIGHLIGHT_PARSING_ERRORS === 'true'
+    ? HIGHLIGHT_PARSING_ERRORS === 'true' || HIGHLIGHT_PARSING_ERRORS === '1'
     : true
 }


### PR DESCRIPTION
We permit to specify 0 or 1 as value for HIGHLIGHT_PARSING_ERRORS
because the variable has a boolean type and because it is common to use
these values for feature toggle in environment variables.