### PR TITLE
Feature comment docs onhover

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -195,10 +195,10 @@ describe('findSymbolCompletions', () => {
 describe('commentsAbove', () => {
   it('returns a string of a comment block above a line', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
-    expect(analyzer.commentsAbove(CURRENT_URI, 22)).toEqual(' doc for func_one')
+    expect(analyzer.commentsAbove(CURRENT_URI, 22)).toEqual('doc for func_one')
 
     expect(analyzer.commentsAbove(CURRENT_URI, 28)).toEqual(
-      ' doc for func_two\n has two lines',
+      'doc for func_two\nhas two lines',
     )
 
     // if there is a line break in the comments

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -192,6 +192,21 @@ describe('findSymbolCompletions', () => {
   })
 })
 
+describe('commentsAbove', () => {
+  it('returns a string of a comment block above a line', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
+    expect(analyzer.commentsAbove(CURRENT_URI, 22)).toEqual(' doc for func_one')
+
+    expect(analyzer.commentsAbove(CURRENT_URI, 28)).toEqual(
+      ' doc for func_two\n has two lines',
+    )
+
+    // if there is a line break in the comments
+    // it should not include the above comment
+    expect(analyzer.commentsAbove(CURRENT_URI, 36)).not.toMatch('this is not included')
+  })
+})
+
 describe('fromRoot', () => {
   it('initializes an analyzer from a root', async () => {
     const parser = await initializeParser()

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -196,14 +196,28 @@ describe('commentsAbove', () => {
   it('returns a string of a comment block above a line', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
     expect(analyzer.commentsAbove(CURRENT_URI, 22)).toEqual('doc for func_one')
+  })
 
+  it('handles line breaks in comments', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
     expect(analyzer.commentsAbove(CURRENT_URI, 28)).toEqual(
-      'doc for func_two\nhas two lines',
+        'doc for func_two\nhas two lines',
     )
+  })
 
-    // if there is a line break in the comments
-    // it should not include the above comment
-    expect(analyzer.commentsAbove(CURRENT_URI, 36)).not.toMatch('this is not included')
+  it('only returns connected comments', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
+    expect(analyzer.commentsAbove(CURRENT_URI, 36)).toEqual('doc for func_three')
+  })
+
+  it('returns null if no comment found', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
+    expect(analyzer.commentsAbove(CURRENT_URI, 45)).toEqual(null)
+  })
+
+  it('works for variables', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
+    expect(analyzer.commentsAbove(CURRENT_URI, 42)).toEqual('works for variables')
   })
 })
 

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -201,7 +201,7 @@ describe('commentsAbove', () => {
   it('handles line breaks in comments', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
     expect(analyzer.commentsAbove(CURRENT_URI, 28)).toEqual(
-        'doc for func_two\nhas two lines',
+      'doc for func_two\nhas two lines',
     )
   })
 
@@ -239,8 +239,7 @@ describe('fromRoot', () => {
 
     expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
 
-    // TODO: maybe not hardcode this number in case
-    // fixture files are added in the future?
+    // if you add a .sh file to testing/fixtures, update this value
     const FIXTURE_FILES_MATCHING_GLOB = 11
 
     // Intro, stats on glob, one file skipped due to shebang, and outro

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -210,7 +210,9 @@ describe('fromRoot', () => {
 
     expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
 
-    const FIXTURE_FILES_MATCHING_GLOB = 10
+    // TODO: maybe not hardcode this number in case
+    // fixture files are added in the future?
+    const FIXTURE_FILES_MATCHING_GLOB = 11
 
     // Intro, stats on glob, one file skipped due to shebang, and outro
     const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 4

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -67,12 +67,35 @@ describe('server', () => {
       {} as any,
     )
 
+    // if user hovers over a function name
+    // the hover contents should contain
+    // the comment above the function definition
+    // see testing/fixtures/comment-doc-on-hover.sh
+    const commentResult = await onHover(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.COMMENT_DOC,
+        },
+        position: {
+          line: 17,
+          character: 0,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
+
     expect(result).toBeDefined()
     expect(result).toEqual({
       contents: {
         kind: 'markdown',
         value: expect.stringContaining('remove directories'),
       },
+    })
+
+    expect(commentResult).toBeDefined()
+    expect(commentResult).toEqual({
+      contents: expect.stringContaining('this function takes two arguments'),
     })
   })
 

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -67,11 +67,22 @@ describe('server', () => {
       {} as any,
     )
 
-    // if user hovers over a function name
-    // the hover contents should contain
-    // the comment above the function definition
-    // see testing/fixtures/comment-doc-on-hover.sh
-    const commentResult = await onHover(
+    expect(result).toBeDefined()
+    expect(result).toEqual({
+      contents: {
+        kind: 'markdown',
+        value: expect.stringContaining('remove directories'),
+      },
+    })
+  })
+
+  it('responds to onHover with function documentation extracted from comments', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
+
+    const onHover = connection.onHover.mock.calls[0][0]
+
+    const result = await onHover(
       {
         textDocument: {
           uri: FIXTURE_URI.COMMENT_DOC,
@@ -87,15 +98,8 @@ describe('server', () => {
 
     expect(result).toBeDefined()
     expect(result).toEqual({
-      contents: {
-        kind: 'markdown',
-        value: expect.stringContaining('remove directories'),
-      },
-    })
-
-    expect(commentResult).toBeDefined()
-    expect(commentResult).toEqual({
-      contents: expect.stringContaining('this function takes two arguments'),
+      contents:
+        'Function defined on line 8\n\nthis is a comment\ndescribing the function\nhello_world\nthis function takes two arguments',
     })
   })
 

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -248,7 +248,7 @@ describe('server', () => {
     )
 
     // Limited set (not using snapshot due to different executables on CI and locally)
-    expect(result && 'length' in result && result.length < 5).toBe(true)
+    expect(result && 'length' in result && result.length < 8).toBe(true)
     expect(result).toEqual(
       expect.arrayContaining([
         {

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -399,6 +399,66 @@ export default class Analyzer {
     return name
   }
 
+  /**
+   * Find a block of comments above a line position
+   */
+  public commentsAbove(uri: string, line: number): string | null {
+    const doc = this.uriToTextDocument[uri]
+
+    const comment_block = []
+
+    // start from the line above
+    let comment_block_index = line - 1
+
+    // check if that line starts with a comment
+    // its possible that some lines
+    // might have whitespace before the comment
+    // begins, so check by iterating from
+    // the start of the line
+    const starts_with_a_comment = (line: string): boolean => {
+      let char_index = 0
+      let char = line.charAt(char_index)
+      while (char === ' ') {
+        char_index += 1
+        char = line.charAt(char_index)
+      }
+      // once we reach a character that is not whitespace
+      // return true if its a comment, false otherwise
+      return char === '#'
+    }
+
+    const exists_and_is_comment = (elm: string): boolean => elm !== undefined && starts_with_a_comment(elm)
+
+    let current_line = doc.getText({
+      start: { line: comment_block_index, character: 0 },
+      end: { line: comment_block_index + 1, character: 0 },
+    })
+
+    while (exists_and_is_comment(current_line)) {
+      // TODO: vscode must have some API for detecting comments
+      // should figure that out instead of hardcoding the # symbol...
+      current_line = current_line.replace('#', '')
+      if (current_line.charAt(current_line.length - 1) === '\n') {
+        // TODO: should preserve comment line endings?
+        // I think not because sometimes comment strings wrap a line
+        // to prevent the line from being too long, and it'd be nice
+        // to see it displayed as a sentence.
+        current_line = current_line.substr(0, current_line.length - 1)
+      }
+      comment_block.push(current_line)
+      comment_block_index -= 1
+      current_line = doc.getText({
+        start: { line: comment_block_index, character: 0 },
+        end: { line: comment_block_index + 1, character: 0 },
+      })
+    }
+
+    // since we searched from bottom up, we then reverse
+    // the lines so that it reads top down.
+    const comment_str = comment_block.reverse().join('\n')
+    return comment_str
+  }
+
   private getAllSymbols(): LSP.SymbolInformation[] {
     // NOTE: this could be cached, it takes < 1 ms to generate for a project with 250 bash files...
     const symbols: LSP.SymbolInformation[] = []

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -415,7 +415,7 @@ export default class Analyzer {
     // is not a comment line
     const getComment = (l: string): null | string => {
       // this regexp has to be defined within the function
-      const commentRegExp = /^\s*\#\s*(.*)/g
+      const commentRegExp = /^\s*#\s*(.*)/g
       const matches = commentRegExp.exec(l)
       return matches ? matches[1].trim() : null
     }
@@ -428,7 +428,7 @@ export default class Analyzer {
     // iterate on every line above and including
     // the current line until getComment returns null
     let currentComment: string | null = ''
-    while (currentComment = getComment(currentLine)) {
+    while ((currentComment = getComment(currentLine))) {
       commentBlock.push(currentComment)
       commentBlockIndex -= 1
       currentLine = doc.getText({

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -405,58 +405,59 @@ export default class Analyzer {
   public commentsAbove(uri: string, line: number): string | null {
     const doc = this.uriToTextDocument[uri]
 
-    const comment_block = []
+    const commentBlock = []
 
     // start from the line above
-    let comment_block_index = line - 1
+    let commentBlockIndex = line - 1
 
     // check if that line starts with a comment
     // its possible that some lines
     // might have whitespace before the comment
     // begins, so check by iterating from
     // the start of the line
-    const starts_with_a_comment = (line: string): boolean => {
-      let char_index = 0
-      let char = line.charAt(char_index)
+    const startsWithAComment = (line: string): boolean => {
+      let charindex = 0
+      let char = line.charAt(charindex)
       while (char === ' ') {
-        char_index += 1
-        char = line.charAt(char_index)
+        charindex += 1
+        char = line.charAt(charindex)
       }
       // once we reach a character that is not whitespace
       // return true if its a comment, false otherwise
       return char === '#'
     }
 
-    const exists_and_is_comment = (elm: string): boolean => elm !== undefined && starts_with_a_comment(elm)
+    const existsAndIsComment = (elm: string): boolean =>
+      elm !== undefined && startsWithAComment(elm)
 
-    let current_line = doc.getText({
-      start: { line: comment_block_index, character: 0 },
-      end: { line: comment_block_index + 1, character: 0 },
+    let currentLine = doc.getText({
+      start: { line: commentBlockIndex, character: 0 },
+      end: { line: commentBlockIndex + 1, character: 0 },
     })
 
-    while (exists_and_is_comment(current_line)) {
+    while (existsAndIsComment(currentLine)) {
       // TODO: vscode must have some API for detecting comments
       // should figure that out instead of hardcoding the # symbol...
-      current_line = current_line.replace('#', '')
-      if (current_line.charAt(current_line.length - 1) === '\n') {
+      currentLine = currentLine.replace('#', '')
+      if (currentLine.charAt(currentLine.length - 1) === '\n') {
         // TODO: should preserve comment line endings?
         // I think not because sometimes comment strings wrap a line
         // to prevent the line from being too long, and it'd be nice
         // to see it displayed as a sentence.
-        current_line = current_line.substr(0, current_line.length - 1)
+        currentLine = currentLine.substr(0, currentLine.length - 1)
       }
-      comment_block.push(current_line)
-      comment_block_index -= 1
-      current_line = doc.getText({
-        start: { line: comment_block_index, character: 0 },
-        end: { line: comment_block_index + 1, character: 0 },
+      commentBlock.push(currentLine)
+      commentBlockIndex -= 1
+      currentLine = doc.getText({
+        start: { line: commentBlockIndex, character: 0 },
+        end: { line: commentBlockIndex + 1, character: 0 },
       })
     }
 
     // since we searched from bottom up, we then reverse
     // the lines so that it reads top down.
-    const comment_str = comment_block.reverse().join('\n')
-    return comment_str
+    const commentStr = commentBlock.reverse().join('\n')
+    return commentStr
   }
 
   private getAllSymbols(): LSP.SymbolInformation[] {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -180,6 +180,11 @@ export default class BashServer {
         return { contents: getMarkdownContent(shellDocumentation) }
       }
     } else {
+      const getCommentsAbove = (uri: string, line: number): string => {
+        const comment = this.analyzer.commentsAbove(uri, line)
+        return comment ? `\n\n${comment}` : ''
+      }
+
       const symbolDocumentation = deduplicateSymbols({
         symbols: this.analyzer.findSymbolsMatchingWord({
           exactMatch: true,
@@ -194,16 +199,15 @@ export default class BashServer {
             ? `${symbolKindToDescription(symbol.kind)} defined in ${path.relative(
                 currentUri,
                 symbol.location.uri,
-              )}\n\n${this.analyzer.commentsAbove(
+              )}${getCommentsAbove(
                 symbol.location.uri,
                 symbol.location.range.start.line,
               )}`
             : `${symbolKindToDescription(symbol.kind)} defined on line ${symbol.location
-                .range.start.line + 1}
-                \n\n${this.analyzer.commentsAbove(
-                  params.textDocument.uri,
-                  symbol.location.range.start.line,
-                )}`,
+                .range.start.line + 1}${getCommentsAbove(
+                params.textDocument.uri,
+                symbol.location.range.start.line,
+              )}`,
         )
 
       if (symbolDocumentation.length === 1) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -196,14 +196,14 @@ export default class BashServer {
                 symbol.location.uri,
               )}\n\n${this.analyzer.commentsAbove(
                 symbol.location.uri,
-                symbol.location.range.start.line
+                symbol.location.range.start.line,
               )}`
             : `${symbolKindToDescription(symbol.kind)} defined on line ${symbol.location
                 .range.start.line + 1}
                 \n\n${this.analyzer.commentsAbove(
                   params.textDocument.uri,
-                  symbol.location.range.start.line
-              )}`,
+                  symbol.location.range.start.line,
+                )}`,
         )
 
       if (symbolDocumentation.length === 1) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -194,9 +194,16 @@ export default class BashServer {
             ? `${symbolKindToDescription(symbol.kind)} defined in ${path.relative(
                 currentUri,
                 symbol.location.uri,
+              )}\n\n${this.analyzer.commentsAbove(
+                symbol.location.uri,
+                symbol.location.range.start.line
               )}`
             : `${symbolKindToDescription(symbol.kind)} defined on line ${symbol.location
-                .range.start.line + 1}`,
+                .range.start.line + 1}
+                \n\n${this.analyzer.commentsAbove(
+                  params.textDocument.uri,
+                  symbol.location.range.start.line
+              )}`,
         )
 
       if (symbolDocumentation.length === 1) {

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -20,7 +20,7 @@ export const FIXTURE_URI = {
   MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
   SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
-  COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`, 
+  COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`,
 }
 
 export const FIXTURE_DOCUMENT = {

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -20,6 +20,7 @@ export const FIXTURE_URI = {
   MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
   SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
+  COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`, 
 }
 
 export const FIXTURE_DOCUMENT = {
@@ -28,6 +29,7 @@ export const FIXTURE_DOCUMENT = {
   MISSING_NODE: getDocument(FIXTURE_URI.MISSING_NODE),
   PARSE_PROBLEMS: getDocument(FIXTURE_URI.PARSE_PROBLEMS),
   SOURCING: getDocument(FIXTURE_URI.SOURCING),
+  COMMENT_DOC: getDocument(FIXTURE_URI.COMMENT_DOC),
 }
 
 export default FIXTURE_DOCUMENT

--- a/testing/fixtures/comment-doc-on-hover.sh
+++ b/testing/fixtures/comment-doc-on-hover.sh
@@ -16,3 +16,24 @@ hello_world() {
 # containing the lines 4 - 7 above
 
 hello_world "bob" "sally"
+
+
+
+# doc for func_one
+func_one() {
+    echo "func_one"
+}
+
+# doc for func_two
+# has two lines
+func_two() {
+    echo "func_two"
+}
+
+
+# this is not included
+
+# doc for func_three
+func_three() {
+    echo "func_three"
+}

--- a/testing/fixtures/comment-doc-on-hover.sh
+++ b/testing/fixtures/comment-doc-on-hover.sh
@@ -37,3 +37,11 @@ func_two() {
 func_three() {
     echo "func_three"
 }
+
+
+# works for variables
+my_var="pizza"
+
+
+my_other_var="no comments above me :("
+

--- a/testing/fixtures/comment-doc-on-hover.sh
+++ b/testing/fixtures/comment-doc-on-hover.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+
+# this is a comment
+# describing the function
+# hello_world
+# this function takes two arguments
+hello_world() {
+    echo "hello world to: $1 and $2"
+}
+
+
+
+# if the user hovers above the below hello_world invocation
+# they should see the comment doc string in a tooltip
+# containing the lines 4 - 7 above
+
+hello_world "bob" "sally"


### PR DESCRIPTION
In most languages, comments above a function serve as documentation for that function. I modified this extension to be able to view the comments that are above functions as tooltips onHover.

It looks like this:

```sh
# this will not be included because
# there is an empty line below

# single positional argument: the commit Id
# returns true if that commit id
# is a merge commit
is_merge_commit() {
    # does something based on $1
    if [[ $1 == "something" ]]; then
        return 0
    fi
}
```

![defined_this_file](https://user-images.githubusercontent.com/39128800/81879103-60f75b80-954f-11ea-9adf-0266e5cf7c37.png)

Also works for functions defined in other files that are included in the `this.uriToDeclarations` from analyser.ts:

```sh
# fn_exists.sh

# does a function exist in this script?
# args: $1 the name of the function
fn_exists() {
    if [[ $1 == "exists" ]]; then
        return 0
    fi
}
# end of fn_exists.sh


# main_script.sh
fn_exists "my_func"
```
![defined_other_file](https://user-images.githubusercontent.com/39128800/81879107-63f24c00-954f-11ea-93da-4523af7b0f2c.png)


I followed the steps in [the development guide](https://github.com/bash-lsp/bash-language-server/blob/master/docs/development-guide.md) before editing the extension and I got this failure:

```
 FAIL  server/src/__tests__/server.test.ts
  ● server › responds to onCompletion with filtered list when word is found
```

so that error is unrelated to my changes. I then ran `yarn test` again after making my changes, and no other tests failed.

I'm new to working on VScode extensions, so let me know if there is a more idiomatic/efficient way to achieve what my code does.
