### PR TITLE
Code completion improvements

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Bash Language Server
 
+## 1.16.0
+
+* Improved completion handler for parameter expansions (https://github.com/bash-lsp/bash-language-server/pull/237)
+
 ## 1.15.0
 
 * Use comments above symbols for documentation (https://github.com/bash-lsp/bash-language-server/pull/234, https://github.com/bash-lsp/bash-language-server/pull/235)
-
 
 ## 1.14.0
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/__snapshots__/server.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/server.test.ts.snap
@@ -4,6 +4,10 @@ exports[`server initializes and responds to capabilities 1`] = `
 Object {
   "completionProvider": Object {
     "resolveProvider": true,
+    "triggerCharacters": Array [
+      "$",
+      "{",
+    ],
   },
   "definitionProvider": true,
   "documentHighlightProvider": true,

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -87,16 +87,26 @@ describe('findSymbolsForFile', () => {
 describe('wordAtPoint', () => {
   it('returns current word at a given point', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 0)).toEqual(null)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 1)).toEqual(null)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 2)).toEqual(null)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 3)).toEqual(null)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 4)).toEqual('rm')
     expect(analyzer.wordAtPoint(CURRENT_URI, 25, 5)).toEqual('rm')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 6)).toEqual(null)
+    expect(analyzer.wordAtPoint(CURRENT_URI, 25, 7)).toEqual('npm-install-')
 
-    // FIXME: grammar issue: else is not found
-    // expect(analyzer.wordAtPoint(CURRENT_URI, 24, 5)).toEqual('else')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 24, 2)).toEqual('else')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 24, 3)).toEqual('else')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 24, 5)).toEqual('else')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 24, 7)).toEqual(null)
 
     expect(analyzer.wordAtPoint(CURRENT_URI, 30, 1)).toEqual(null)
 
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 2)).toEqual('ret')
     expect(analyzer.wordAtPoint(CURRENT_URI, 30, 3)).toEqual('ret')
     expect(analyzer.wordAtPoint(CURRENT_URI, 30, 4)).toEqual('ret')
-    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 5)).toEqual('ret')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 5)).toEqual('=')
 
     expect(analyzer.wordAtPoint(CURRENT_URI, 38, 5)).toEqual('configures')
   })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -418,4 +418,33 @@ Helper function to add a user",
       ]
     `)
   })
+
+  it('responds to onCompletion with all variables when starting to expand parameters', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
+
+    const onCompletion = connection.onCompletion.mock.calls[0][0]
+
+    const result: any = await onCompletion(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.SOURCING,
+        },
+        position: {
+          // $
+          line: 14,
+          character: 7,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
+
+    const itemKinds = result.map((item: any) => item.kind)
+
+    // they are all variables
+    expect(itemKinds.every((kind: any) => kind === lsp.CompletionItemKind.Variable)).toBe(
+      true,
+    )
+  })
 })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -181,7 +181,7 @@ describe('server', () => {
       {} as any,
     )
 
-    expect(result2).toMatchInlineSnapshot(`null`)
+    expect(result2).toMatchInlineSnapshot(`Array []`)
   })
 
   it('responds to onWorkspaceSymbol', async () => {
@@ -279,9 +279,9 @@ describe('server', () => {
           uri: FIXTURE_URI.INSTALL,
         },
         position: {
-          // else
-          line: 24,
-          character: 5,
+          // empty space
+          line: 26,
+          character: 0,
         },
       },
       {} as any,
@@ -289,7 +289,7 @@ describe('server', () => {
     )
 
     // Entire list
-    expect(result && 'length' in result && result.length > 50).toBe(true)
+    expect(result && 'length' in result && result.length).toBeGreaterThanOrEqual(50)
   })
 
   it('responds to onCompletion with empty list when word is a comment', async () => {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -440,11 +440,9 @@ Helper function to add a user",
       {} as any,
     )
 
-    const itemKinds = result.map((item: any) => item.kind)
-
     // they are all variables
-    expect(itemKinds.every((kind: any) => kind === lsp.CompletionItemKind.Variable)).toBe(
-      true,
-    )
+    expect(Array.from(new Set(result.map((item: any) => item.kind)))).toEqual([
+      lsp.CompletionItemKind.Variable,
+    ])
   })
 })

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -371,32 +371,19 @@ export default class Analyzer {
    */
   public wordAtPoint(uri: string, line: number, column: number): string | null {
     const document = this.uriToTreeSitterTrees[uri]
-    const contents = this.uriToFileContent[uri]
 
     if (!document.rootNode) {
       // Check for lacking rootNode (due to failed parse?)
       return null
     }
 
-    const point = { row: line, column }
+    const node = document.rootNode.descendantForPosition({ row: line, column })
 
-    const node = TreeSitterUtil.namedLeafDescendantForPosition(point, document.rootNode)
-
-    if (!node) {
+    if (!node || node.childCount > 0 || node.text.trim() === '') {
       return null
     }
 
-    const start = node.startIndex
-    const end = node.endIndex
-    const name = contents.slice(start, end)
-
-    // Hack. Might be a problem with the grammar.
-    // TODO: Document this with a test case
-    if (name.endsWith('=')) {
-      return name.slice(0, name.length - 1)
-    }
-
-    return name
+    return node.text.trim()
   }
 
   /**

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -434,6 +434,10 @@ export default class Analyzer {
     return null
   }
 
+  public getAllVariableSymbols(): LSP.SymbolInformation[] {
+    return this.getAllSymbols().filter(symbol => symbol.kind === LSP.SymbolKind.Variable)
+  }
+
   private getAllSymbols(): LSP.SymbolInformation[] {
     // NOTE: this could be cached, it takes < 1 ms to generate for a project with 250 bash files...
     const symbols: LSP.SymbolInformation[] = []

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -100,6 +100,7 @@ export default class BashServer {
       textDocumentSync: LSP.TextDocumentSyncKind.Full,
       completionProvider: {
         resolveProvider: true,
+        triggerCharacters: ['$', '{'],
       },
       hoverProvider: true,
       documentHighlightProvider: true,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -313,6 +313,9 @@ export default class BashServer {
 
     const currentUri = params.textDocument.uri
 
+    // TODO: an improvement here would be to detect if the current word is
+    // not only a parameter expansion prefix, but also if the word is actually
+    // inside a parameter expansion (e.g. auto completing on a word $MY_VARIA).
     const shouldCompleteOnVariables = word
       ? PARAMETER_EXPANSION_PREFIXES.has(word)
       : false

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,7 +13,7 @@ import { BashCompletionItem, CompletionItemDataType } from './types'
 import { uniqueBasedOnHash } from './util/array'
 import { getShellDocumentation } from './util/sh'
 
-const PARAMETER_EXPANSION_PREFIXES = new Set(['$', '${', '${#'])
+const PARAMETER_EXPANSION_PREFIXES = new Set(['$', '${'])
 
 /**
  * The BashServer glues together the separate components to implement
@@ -331,6 +331,10 @@ export default class BashServer {
           })
 
     if (shouldCompleteOnVariables) {
+      // In case we auto complete on a word that starts a parameter expansion,
+      // we do not return anything else than variable/parameter suggestions.
+      // Note: that LSP clients should not call onCompletion in the middle
+      // of a word, so the following should work for client.
       return symbolCompletions
     }
 

--- a/server/src/util/__tests__/sh.test.ts
+++ b/server/src/util/__tests__/sh.test.ts
@@ -20,6 +20,11 @@ describe('getDocumentation', () => {
     expect(lines[1]).toContain('list directory contents')
   })
 
+  it('skips documentation for some builtins', async () => {
+    const result = await sh.getShellDocumentation({ word: 'else' })
+    expect(result).toEqual(null)
+  })
+
   it('sanity checks the given word', async () => {
     await expect(sh.getShellDocumentation({ word: 'ls foo' })).rejects.toThrow()
   })

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -24,6 +24,18 @@ export function execShellScript(body: string): Promise<string> {
   })
 }
 
+// Currently only reserved words where documentation doesn't make sense.
+// At least on OS X these just return the builtin man. On ubuntu there
+// are no documentaiton for them.
+const WORDS_WITHOUT_DOCUMENTATION = new Set([
+  'else',
+  'fi',
+  'then',
+  'esac',
+  'elif',
+  'done',
+])
+
 /**
  * Get documentation for the given word by usingZZ help and man.
  */
@@ -34,6 +46,10 @@ export async function getShellDocumentationWithoutCache({
 }): Promise<string | null> {
   if (word.split(' ').length > 1) {
     throw new Error(`lookupDocumentation should be given a word, received "${word}"`)
+  }
+
+  if (WORDS_WITHOUT_DOCUMENTATION.has(word)) {
+    return null
   }
 
   const DOCUMENTATION_COMMANDS = [

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -1,5 +1,5 @@
 import { Range } from 'vscode-languageserver/lib/main'
-import { Point, SyntaxNode } from 'web-tree-sitter'
+import { SyntaxNode } from 'web-tree-sitter'
 
 export function forEach(node: SyntaxNode, cb: (n: SyntaxNode) => void) {
   cb(node)
@@ -51,58 +51,4 @@ export function findParent(
     node = node.parent
   }
   return null
-}
-
-/**
- * Given a tree and a point, try to find the named leaf node that the point corresponds to.
- * This is a helper for wordAtPoint, useful in cases where the point occurs at the boundary of
- * a word so the normal behavior of "namedDescendantForPosition" does not find the desired leaf.
- * For example, if you do
- * > (new Parser()).setLanguage(bash).parse("echo 42").rootNode.descendantForIndex(4).text
- * then you get 'echo 42', not the leaf node for 'echo'.
- *
- * TODO: the need for this function might reveal a flaw in tree-sitter-bash.
- */
-export function namedLeafDescendantForPosition(
-  point: Point,
-  rootNode: SyntaxNode,
-): SyntaxNode | null {
-  const node = rootNode.namedDescendantForPosition(point)
-
-  if (node.childCount === 0) {
-    return node
-  } else {
-    // The node wasn't a leaf. Try to figure out what word we should use.
-    const nodeToUse = searchForLeafNode(point, node)
-    if (nodeToUse) {
-      return nodeToUse
-    } else {
-      return null
-    }
-  }
-}
-
-function searchForLeafNode(point: Point, parent: SyntaxNode): SyntaxNode | null {
-  let child = parent.firstNamedChild
-
-  while (child) {
-    if (
-      pointsEqual(child.startPosition, point) ||
-      pointsEqual(child.endPosition, point)
-    ) {
-      if (child.childCount === 0) {
-        return child
-      } else {
-        return searchForLeafNode(point, child)
-      }
-    }
-
-    child = child.nextNamedSibling
-  }
-
-  return null
-}
-
-function pointsEqual(point1: Point, point2: Point) {
-  return point1.row === point2.row && point1.column === point2.column
 }

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -11,3 +11,5 @@ add_a_us
 BOLD=`tput bold` # redefined
 
 echo $BOL
+
+echo "$"


### PR DESCRIPTION
Fixes https://github.com/bash-lsp/bash-language-server/issues/236

This PR enables code completion improvements:
- completion support for parameter expansions
- lots of words are now parsed correctly like `else` (we had a bug in the handling around tree-sitter)
- reduces some unnecessary complexities

### Screenshots (before and after)

<img width="45%" alt="Screenshot 2020-05-20 10 42 28" src="https://user-images.githubusercontent.com/1260305/82427322-3f373080-9a89-11ea-9886-5bf408c22fcd.png"><img width="45%" alt="Screenshot 2020-05-20 10 42 34" src="https://user-images.githubusercontent.com/1260305/82427326-3fcfc700-9a89-11ea-8835-34460d759ec1.png">

<img width="45%" alt="Screenshot 2020-05-20 10 43 07" src="https://user-images.githubusercontent.com/1260305/82427333-41998a80-9a89-11ea-9957-06fcbd511a64.png"><img width="45%" alt="Screenshot 2020-05-20 10 42 42" src="https://user-images.githubusercontent.com/1260305/82427330-4100f400-9a89-11ea-8308-76a2ecc53b06.png">

