### PR TITLE
Fix brace expansion bug

### DIFF
--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -316,6 +316,30 @@ describe('server', () => {
     expect(result).toEqual([])
   })
 
+  it('responds to onCompletion with empty list when word is {', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
+
+    const onCompletion = connection.onCompletion.mock.calls[0][0]
+
+    const result = await onCompletion(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.ISSUE101,
+        },
+        position: {
+          // the opening brace '{' to 'add_a_user'
+          line: 4,
+          character: 0,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
+
+    expect(result).toEqual([])
+  })
+
   it('responds to onCompletion when word is found in another file', async () => {
     const { connection, server } = await initializeServer()
     server.register(connection)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -316,6 +316,12 @@ export default class BashServer {
       // Inside a comment block
       return []
     }
+    if (word && word === '{') {
+      // We should not complete when it is not prefixed by a $.
+      // This case needs to be here
+      // because { is a completionProvider triggerCharacter.
+      return []
+    }
 
     const currentUri = params.textDocument.uri
 


### PR DESCRIPTION
as described in #239 

Please let me know if there's a better way than my `validCompletions.filter` approach.