### PR TITLE
Fix issue 241

### DIFF
--- a/server/src/util/__tests__/sh.test.ts
+++ b/server/src/util/__tests__/sh.test.ts
@@ -1,49 +1,16 @@
-import * as ChildPorcess from 'child_process'
-// @ts-ignore
-ChildPorcess.spawn = jest.fn(ChildPorcess.spawn)
-
 /* eslint-disable no-useless-escape */
 import * as sh from '../sh'
 
 describe('execShellScript', () => {
   it('resolves if childprocess sends close signal', async () => {
-    // @ts-ignore
-    ChildPorcess.spawn.mockReturnValueOnce({
-      stdout: {
-        on: (eventName: string, cb: (s: string) => {}) => {
-          setImmediate(() => {
-            cb('abc')
-          })
-        },
-      },
-      on: (eventName: string, cb: (n: number) => {}) => {
-        setImmediate(() => {
-          cb(0)
-        })
-      },
-    })
-    return expect(sh.execShellScript('something')).resolves.toBe('abc')
+    return expect(sh.execShellScript('echo')).resolves
   })
 
   it('rejects if childprocess sends error signal', async () => {
-    // @ts-ignore
-    ChildPorcess.spawn.mockReturnValueOnce({
-      stdout: {
-        on: (eventName: string, cb: (s: string) => {}) => {
-          setImmediate(() => {
-            cb('abc')
-          })
-        },
-      },
-      on: (eventName: string, cb: (err: Error) => {}) => {
-        setImmediate(() => {
-          cb(new Error('err'))
-        })
-      },
-    })
-    return expect(sh.execShellScript('something')).rejects.toBe(
-      'Failed to execute something',
-    )
+    // an error is sent if child_process cant spawn 'some-nonexistant-command'
+    return expect(
+      sh.execShellScript('something', 'some-nonexistant-command'),
+    ).rejects.toBe('Failed to execute something')
   })
 })
 

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -10,17 +10,20 @@ export function execShellScript(body: string): Promise<string> {
   return new Promise((resolve, reject) => {
     let output = ''
 
-    process.stdout.on('data', buffer => {
-      output += buffer
-    })
-
-    process.on('close', returnCode => {
+    const handleClose = (returnCode: number | Error) => {
       if (returnCode === 0) {
         resolve(output)
       } else {
         reject(`Failed to execute ${body}`)
       }
+    }
+
+    process.stdout.on('data', buffer => {
+      output += buffer
     })
+
+    process.on('close', handleClose)
+    process.on('error', handleClose)
   })
 }
 

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -3,9 +3,9 @@ import * as ChildProcess from 'child_process'
 /**
  * Execute the following sh program.
  */
-export function execShellScript(body: string): Promise<string> {
+export function execShellScript(body: string, cmd = 'bash'): Promise<string> {
   const args = ['-c', body]
-  const process = ChildProcess.spawn('bash', args)
+  const process = ChildProcess.spawn(cmd, args)
 
   return new Promise((resolve, reject) => {
     let output = ''


### PR DESCRIPTION
closes #241 

execShellScript needs to check for errors in addition to close signals, otherwise it never rejects.

I added tests for resolving and rejecting, but they are pretty bad IMO. Im not well versed in typescript, so I couldn't figure out how to use jest mock functions other than adding `// @ts-ignore`, so let me know if there's a better way to accomplish this