### PR TITLE
Issue #233 - "Failed to parse expression" with modulus operator

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -82,6 +82,11 @@ describe('findSymbolsForFile', () => {
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
+
+  it('issue 233 failed to parse expression for modulus operator surrounded by spaces', () => {
+    const diagnostics = analyzer.analyze(CURRENT_URI, FIXTURES.ISSUE233)
+    expect(diagnostics).toEqual([])
+  })
 })
 
 describe('wordAtPoint', () => {
@@ -250,7 +255,7 @@ describe('fromRoot', () => {
     expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
 
     // if you add a .sh file to testing/fixtures, update this value
-    const FIXTURE_FILES_MATCHING_GLOB = 11
+    const FIXTURE_FILES_MATCHING_GLOB = 12
 
     // Intro, stats on glob, one file skipped due to shebang, and outro
     const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 4

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -17,6 +17,7 @@ export const FIXTURE_URI = {
   INSTALL: `file://${path.join(FIXTURE_FOLDER, 'install.sh')}`,
   ISSUE101: `file://${path.join(FIXTURE_FOLDER, 'issue101.sh')}`,
   ISSUE206: `file://${path.join(FIXTURE_FOLDER, 'issue206.sh')}`,
+  ISSUE233: `file://${path.join(FIXTURE_FOLDER, 'issue233.sh')}`,
   MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
   SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
@@ -26,6 +27,7 @@ export const FIXTURE_URI = {
 export const FIXTURE_DOCUMENT = {
   INSTALL: getDocument(FIXTURE_URI.INSTALL),
   ISSUE101: getDocument(FIXTURE_URI.ISSUE101),
+  ISSUE233: getDocument(FIXTURE_URI.ISSUE233),
   MISSING_NODE: getDocument(FIXTURE_URI.MISSING_NODE),
   PARSE_PROBLEMS: getDocument(FIXTURE_URI.PARSE_PROBLEMS),
   SOURCING: getDocument(FIXTURE_URI.SOURCING),

--- a/testing/fixtures/issue233.sh
+++ b/testing/fixtures/issue233.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ((100 % 4 == 0)); then
+  echo "OK"
+fi
+
+if ((100%4 == 0)); then
+  echo "OK"
+fi


### PR DESCRIPTION
Failing test for https://github.com/bash-lsp/bash-language-server/issues/233 "Failed to parse expression" when there is a space surrouding the modulus operator in an arithmetic expression.

I looked at the [bash-tree-sitter grammar.json](https://github.com/tree-sitter/tree-sitter-bash/blob/master/src/grammar.json) and found the `%` operator but it was too much for me to understand how to approach fixing this at a glance. I hope this failing test can at least help you reproduce the issue and confirm when it's fixed. This new test currently fails with the error:

```
 FAIL  server/src/__tests__/analyzer.test.ts
  ● findSymbolsForFile › issue 233 failed to parse expression for modulus operator surrounded by spaces

    expect(received).toEqual(expected) // deep equality

    - Expected  -  1
    + Received  + 16

    - Array []
    + Array [
    +   Object {
    +     "message": "Failed to parse expression",
    +     "range": Object {
    +       "end": Object {
    +         "character": 12,
    +         "line": 2,
    +       },
    +       "start": Object {
    +         "character": 9,
    +         "line": 2,
    +       },
    +     },
    +     "severity": 1,
    +   },
    + ]

      86 |   it('issue 233 failed to parse expression for modulus operator surrounded by spaces', () => {
      87 |     const diagnostics = analyzer.analyze(CURRENT_URI, FIXTURES.ISSUE233)
    > 88 |     expect(diagnostics).toEqual([])
         |                         ^
      89 |   })
      90 | })
      91 | 

      at Object.<anonymous> (server/src/__tests__/analyzer.test.ts:88:25)
```