### PR TITLE
Changed vim-lsp settings in README (whitelist -> allowlist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ if executable('bash-language-server')
   au User lsp_setup call lsp#register_server({
         \ 'name': 'bash-language-server',
         \ 'cmd': {server_info->[&shell, &shellcmdflag, 'bash-language-server start']},
-        \ 'whitelist': ['sh'],
+        \ 'allowlist': ['sh'],
         \ })
 endif
 ```


### PR DESCRIPTION
## Description

"vim-lsp" configuration parameter has been changed from `whitelist` to `allowlist`, and It is.

`whitelist` configuration parameters will not be available in the future, so the README has been modified.

## REF

https://github.com/prabirshrestha/vim-lsp/commit/32fae1f0e9c0c2c21361d0bb94f119f9ae65a118
