### PR TITLE
Default to hide parsing errors

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Bash Language Server
 
+## 1.17.0
+
+* Default configuration change: parsing errors are not highlighted as problems (as the grammar is buggy)
 
 ## 1.16.1
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -49,10 +49,10 @@ describe('getGlobPattern', () => {
 })
 
 describe('highlightParsingError', () => {
-  it('default to true', () => {
+  it('default to false', () => {
     process.env = {}
     const result = config.getHighlightParsingError()
-    expect(result).toEqual(true)
+    expect(result).toEqual(false)
   })
 
   it('parses environment variable', () => {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -18,5 +18,5 @@ export function getHighlightParsingError(): boolean {
   const { HIGHLIGHT_PARSING_ERRORS } = process.env
   return typeof HIGHLIGHT_PARSING_ERRORS !== 'undefined'
     ? HIGHLIGHT_PARSING_ERRORS === 'true' || HIGHLIGHT_PARSING_ERRORS === '1'
-    : true
+    : false
 }

--- a/vscode-client/CHANGELOG.md
+++ b/vscode-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash IDE
 
+## 1.11.0
+
+* Default configuration change: parsing errors are not highlighted as problems (as the grammar is buggy)
+
 ## 1.10.2
 
 * Upgrade language server to 1.16.1 (fix brace expansion bug and crash when bash is not installed)

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -4,7 +4,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "publisher": "mads-hartmann",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
         },
         "bashIde.highlightParsingErrors": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Controls if parsing errors will be highlighted as problems."
         },
         "bashIde.explainshellEndpoint": {


### PR DESCRIPTION
The grammar is still buggy and under development, so let us default to hide parsing errors.

Fixes https://github.com/bash-lsp/bash-language-server/issues/260