### PR TITLE
Complete command line arguments

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -112,6 +112,24 @@ describe('wordAtPoint', () => {
   })
 })
 
+describe('commandNameAtPoint', () => {
+  it('returns current command name at a given point', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 15, 0)).toEqual(null)
+
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 20, 2)).toEqual('curl')
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 20, 15)).toEqual('curl')
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 20, 19)).toEqual('curl')
+
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 26, 4)).toEqual('echo')
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 26, 9)).toEqual('echo')
+
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 38, 13)).toEqual('env')
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 38, 24)).toEqual('grep')
+    expect(analyzer.commandNameAtPoint(CURRENT_URI, 38, 44)).toEqual('sed')
+  })
+})
+
 describe('findSymbolCompletions', () => {
   it('return a list of symbols across the workspace', () => {
     analyzer.analyze('install.sh', FIXTURES.INSTALL)

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -268,7 +268,7 @@ describe('fromRoot', () => {
     expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
 
     // if you add a .sh file to testing/fixtures, update this value
-    const FIXTURE_FILES_MATCHING_GLOB = 11
+    const FIXTURE_FILES_MATCHING_GLOB = 12
 
     // Intro, stats on glob, one file skipped due to shebang, and outro
     const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 4

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -267,6 +267,41 @@ describe('server', () => {
     )
   })
 
+  it('responds to onCompletion with options list when command name is found', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
+
+    const onCompletion = connection.onCompletion.mock.calls[0][0]
+
+    const result = await onCompletion(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.OPTIONS,
+        },
+        position: {
+          // grep --line-
+          line: 2,
+          character: 12,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          data: {
+            name: expect.stringMatching(RegExp('--line-.*')),
+            type: CompletionItemDataType.Symbol,
+          },
+          kind: expect.any(Number),
+          label: expect.stringMatching(RegExp('--line-.*')),
+        },
+      ]),
+    )
+  })
+
   it('responds to onCompletion with entire list when no word is found', async () => {
     const { connection, server } = await initializeServer()
     server.register(connection)

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -401,19 +401,17 @@ export default class Analyzer {
    * Find the name of the command at the given point.
    */
   public commandNameAtPoint(uri: string, line: number, column: number): string | null {
-    const node = this.nodeAtPoint(uri, line, column)
+    let node = this.nodeAtPoint(uri, line, column)
 
-    if (!node || node.childCount > 0 || node.text.trim() === '') {
+    while (node && node.type !== 'command') {
+      node = node.parent
+    }
+
+    if (!node) {
       return null
     }
 
-    const { parent } = node
-
-    if (!parent || parent.type !== 'command') {
-      return null
-    }
-
-    const firstChild = parent.firstNamedChild
+    const firstChild = node.firstNamedChild
 
     if (!firstChild || firstChild.type !== 'command_name') {
       return null

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -123,11 +123,11 @@ export default class Analyzer {
    */
   public findDefinition(name: string): LSP.Location[] {
     const symbols: LSP.SymbolInformation[] = []
-    Object.keys(this.uriToDeclarations).forEach(uri => {
+    Object.keys(this.uriToDeclarations).forEach((uri) => {
       const declarationNames = this.uriToDeclarations[uri][name] || []
-      declarationNames.forEach(d => symbols.push(d))
+      declarationNames.forEach((d) => symbols.push(d))
     })
-    return symbols.map(s => s.location)
+    return symbols.map((s) => s.location)
   }
 
   /**
@@ -175,10 +175,7 @@ export default class Analyzer {
 
     // FIXME: type the response and unit test it
     const explainshellResponse = await request({
-      uri: URI(endpoint)
-        .path('/api/explain')
-        .addQuery('cmd', cmd)
-        .toString(),
+      uri: URI(endpoint).path('/api/explain').addQuery('cmd', cmd).toString(),
       json: true,
     })
 
@@ -216,7 +213,7 @@ export default class Analyzer {
    */
   public findReferences(name: string): LSP.Location[] {
     const uris = Object.keys(this.uriToTreeSitterTrees)
-    return flattenArray(uris.map(uri => this.findOccurrences(uri, name)))
+    return flattenArray(uris.map((uri) => this.findOccurrences(uri, name)))
   }
 
   /**
@@ -229,7 +226,7 @@ export default class Analyzer {
 
     const locations: LSP.Location[] = []
 
-    TreeSitterUtil.forEach(tree.rootNode, n => {
+    TreeSitterUtil.forEach(tree.rootNode, (n) => {
       let name: null | string = null
       let range: null | LSP.Range = null
 
@@ -273,12 +270,12 @@ export default class Analyzer {
   }): LSP.SymbolInformation[] {
     const symbols: LSP.SymbolInformation[] = []
 
-    Object.keys(this.uriToDeclarations).forEach(uri => {
+    Object.keys(this.uriToDeclarations).forEach((uri) => {
       const declarationsInFile = this.uriToDeclarations[uri] || {}
-      Object.keys(declarationsInFile).map(name => {
+      Object.keys(declarationsInFile).map((name) => {
         const match = exactMatch ? name === word : name.startsWith(word)
         if (match) {
-          declarationsInFile[name].forEach(symbol => symbols.push(symbol))
+          declarationsInFile[name].forEach((symbol) => symbols.push(symbol))
         }
       })
     })
@@ -325,7 +322,10 @@ export default class Analyzer {
         const name = contents.slice(named.startIndex, named.endIndex)
         const namedDeclarations = this.uriToDeclarations[uri][name] || []
 
-        const parent = TreeSitterUtil.findParent(n, p => p.type === 'function_definition')
+        const parent = TreeSitterUtil.findParent(
+          n,
+          (p) => p.type === 'function_definition',
+        )
         const parentName =
           parent && parent.firstNamedChild
             ? contents.slice(
@@ -369,7 +369,11 @@ export default class Analyzer {
   /**
    * Find the node at the given point.
    */
-  private nodeAtPoint(uri: string, line: number, column: number): Parser.SyntaxNode | null {
+  private nodeAtPoint(
+    uri: string,
+    line: number,
+    column: number,
+  ): Parser.SyntaxNode | null {
     const document = this.uriToTreeSitterTrees[uri]
 
     if (!document.rootNode) {
@@ -406,13 +410,13 @@ export default class Analyzer {
     const parent = node.parent
 
     if (!parent || parent.type !== 'command') {
-        return null
+      return null
     }
 
     const firstChild = parent.firstNamedChild
 
     if (!firstChild || firstChild.type !== 'command_name') {
-        return null
+      return null
     }
 
     return firstChild.text.trim()
@@ -467,17 +471,19 @@ export default class Analyzer {
   }
 
   public getAllVariableSymbols(): LSP.SymbolInformation[] {
-    return this.getAllSymbols().filter(symbol => symbol.kind === LSP.SymbolKind.Variable)
+    return this.getAllSymbols().filter(
+      (symbol) => symbol.kind === LSP.SymbolKind.Variable,
+    )
   }
 
   private getAllSymbols(): LSP.SymbolInformation[] {
     // NOTE: this could be cached, it takes < 1 ms to generate for a project with 250 bash files...
     const symbols: LSP.SymbolInformation[] = []
 
-    Object.keys(this.uriToDeclarations).forEach(uri => {
-      Object.keys(this.uriToDeclarations[uri]).forEach(name => {
+    Object.keys(this.uriToDeclarations).forEach((uri) => {
+      Object.keys(this.uriToDeclarations[uri]).forEach((name) => {
         const declarationNames = this.uriToDeclarations[uri][name] || []
-        declarationNames.forEach(d => symbols.push(d))
+        declarationNames.forEach((d) => symbols.push(d))
       })
     })
 

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -367,9 +367,9 @@ export default class Analyzer {
   }
 
   /**
-   * Find the full word at the given point.
+   * Find the node at the given point.
    */
-  public wordAtPoint(uri: string, line: number, column: number): string | null {
+  private nodeAtPoint(uri: string, line: number, column: number): Parser.SyntaxNode | null {
     const document = this.uriToTreeSitterTrees[uri]
 
     if (!document.rootNode) {
@@ -377,13 +377,45 @@ export default class Analyzer {
       return null
     }
 
-    const node = document.rootNode.descendantForPosition({ row: line, column })
+    return document.rootNode.descendantForPosition({ row: line, column })
+  }
+
+  /**
+   * Find the full word at the given point.
+   */
+  public wordAtPoint(uri: string, line: number, column: number): string | null {
+    const node = this.nodeAtPoint(uri, line, column)
 
     if (!node || node.childCount > 0 || node.text.trim() === '') {
       return null
     }
 
     return node.text.trim()
+  }
+
+  /**
+   * Find the name of the command at the given point.
+   */
+  public commandNameAtPoint(uri: string, line: number, column: number): string | null {
+    const node = this.nodeAtPoint(uri, line, column)
+
+    if (!node || node.childCount > 0 || node.text.trim() === '') {
+      return null
+    }
+
+    const parent = node.parent
+
+    if (!parent || parent.type !== 'command') {
+        return null
+    }
+
+    const firstChild = parent.firstNamedChild
+
+    if (!firstChild || firstChild.type !== 'command_name') {
+        return null
+    }
+
+    return firstChild.text.trim()
   }
 
   /**

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -123,11 +123,11 @@ export default class Analyzer {
    */
   public findDefinition(name: string): LSP.Location[] {
     const symbols: LSP.SymbolInformation[] = []
-    Object.keys(this.uriToDeclarations).forEach((uri) => {
+    Object.keys(this.uriToDeclarations).forEach(uri => {
       const declarationNames = this.uriToDeclarations[uri][name] || []
-      declarationNames.forEach((d) => symbols.push(d))
+      declarationNames.forEach(d => symbols.push(d))
     })
-    return symbols.map((s) => s.location)
+    return symbols.map(s => s.location)
   }
 
   /**
@@ -175,7 +175,10 @@ export default class Analyzer {
 
     // FIXME: type the response and unit test it
     const explainshellResponse = await request({
-      uri: URI(endpoint).path('/api/explain').addQuery('cmd', cmd).toString(),
+      uri: URI(endpoint)
+        .path('/api/explain')
+        .addQuery('cmd', cmd)
+        .toString(),
       json: true,
     })
 
@@ -213,7 +216,7 @@ export default class Analyzer {
    */
   public findReferences(name: string): LSP.Location[] {
     const uris = Object.keys(this.uriToTreeSitterTrees)
-    return flattenArray(uris.map((uri) => this.findOccurrences(uri, name)))
+    return flattenArray(uris.map(uri => this.findOccurrences(uri, name)))
   }
 
   /**
@@ -226,7 +229,7 @@ export default class Analyzer {
 
     const locations: LSP.Location[] = []
 
-    TreeSitterUtil.forEach(tree.rootNode, (n) => {
+    TreeSitterUtil.forEach(tree.rootNode, n => {
       let name: null | string = null
       let range: null | LSP.Range = null
 
@@ -270,12 +273,12 @@ export default class Analyzer {
   }): LSP.SymbolInformation[] {
     const symbols: LSP.SymbolInformation[] = []
 
-    Object.keys(this.uriToDeclarations).forEach((uri) => {
+    Object.keys(this.uriToDeclarations).forEach(uri => {
       const declarationsInFile = this.uriToDeclarations[uri] || {}
-      Object.keys(declarationsInFile).map((name) => {
+      Object.keys(declarationsInFile).map(name => {
         const match = exactMatch ? name === word : name.startsWith(word)
         if (match) {
-          declarationsInFile[name].forEach((symbol) => symbols.push(symbol))
+          declarationsInFile[name].forEach(symbol => symbols.push(symbol))
         }
       })
     })
@@ -322,10 +325,7 @@ export default class Analyzer {
         const name = contents.slice(named.startIndex, named.endIndex)
         const namedDeclarations = this.uriToDeclarations[uri][name] || []
 
-        const parent = TreeSitterUtil.findParent(
-          n,
-          (p) => p.type === 'function_definition',
-        )
+        const parent = TreeSitterUtil.findParent(n, p => p.type === 'function_definition')
         const parentName =
           parent && parent.firstNamedChild
             ? contents.slice(
@@ -407,7 +407,7 @@ export default class Analyzer {
       return null
     }
 
-    const parent = node.parent
+    const { parent } = node
 
     if (!parent || parent.type !== 'command') {
       return null
@@ -471,19 +471,17 @@ export default class Analyzer {
   }
 
   public getAllVariableSymbols(): LSP.SymbolInformation[] {
-    return this.getAllSymbols().filter(
-      (symbol) => symbol.kind === LSP.SymbolKind.Variable,
-    )
+    return this.getAllSymbols().filter(symbol => symbol.kind === LSP.SymbolKind.Variable)
   }
 
   private getAllSymbols(): LSP.SymbolInformation[] {
     // NOTE: this could be cached, it takes < 1 ms to generate for a project with 250 bash files...
     const symbols: LSP.SymbolInformation[] = []
 
-    Object.keys(this.uriToDeclarations).forEach((uri) => {
-      Object.keys(this.uriToDeclarations[uri]).forEach((name) => {
+    Object.keys(this.uriToDeclarations).forEach(uri => {
+      Object.keys(this.uriToDeclarations[uri]).forEach(name => {
         const declarationNames = this.uriToDeclarations[uri][name] || []
-        declarationNames.forEach((d) => symbols.push(d))
+        declarationNames.forEach(d => symbols.push(d))
       })
     })
 

--- a/server/src/executables.ts
+++ b/server/src/executables.ts
@@ -17,11 +17,11 @@ export default class Executables {
    */
   public static fromPath(path: string): Promise<Executables> {
     const paths = path.split(':')
-    const promises = paths.map(x => findExecutablesInPath(x))
+    const promises = paths.map((x) => findExecutablesInPath(x))
     return Promise.all(promises)
       .then(ArrayUtil.flatten)
       .then(ArrayUtil.uniq)
-      .then(executables => new Executables(executables))
+      .then((executables) => new Executables(executables))
   }
 
   private executables: Set<string>

--- a/server/src/executables.ts
+++ b/server/src/executables.ts
@@ -17,11 +17,11 @@ export default class Executables {
    */
   public static fromPath(path: string): Promise<Executables> {
     const paths = path.split(':')
-    const promises = paths.map((x) => findExecutablesInPath(x))
+    const promises = paths.map(x => findExecutablesInPath(x))
     return Promise.all(promises)
       .then(ArrayUtil.flatten)
       .then(ArrayUtil.uniq)
-      .then((executables) => new Executables(executables))
+      .then(executables => new Executables(executables))
   }
 
   private executables: Set<string>

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -uo pipefail
+
 DATADIR="$(pkg-config --variable=datadir bash-completion)"
 
 source "$DATADIR/bash-completion/bash_completion"

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source /usr/share/bash-completion/bash_completion
+
+COMP_LINE="$*"
+COMP_WORDS=("$@")
+COMP_CWORD="${#COMP_WORDS[@]}"
+((COMP_CWORD--))
+COMP_POINT="${#COMP_LINE}"
+COMP_WORDBREAKS='"'"'><=;|&(:"
+
+_command_offset 0 2> /dev/null
+
+if (( ${#COMPREPLY[@]} == 0 ))
+then
+	_longopt "${COMP_WORDS[0]}"
+fi
+
+printf "%s\t" "${COMPREPLY[@]}"

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -15,7 +15,12 @@ _command_offset 0 2> /dev/null
 
 if (( ${#COMPREPLY[@]} == 0 ))
 then
-	_longopt "${COMP_WORDS[0]}"
+	# Disabled by default because _longopt executes the program
+	# to get its options.
+	if (( ${BASH_LSP_COMPLETE_LONGOPTS} == 1 ))
+	then
+		_longopt "${COMP_WORDS[0]}"
+	fi
 fi
 
 printf "%s\t" "${COMPREPLY[@]}"

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -2,6 +2,12 @@
 
 DATADIR="$(pkg-config --variable=datadir bash-completion)"
 
+# Exit if bash-completion isn't installed.
+if (( $? != 0 ))
+then
+	exit 1
+fi
+
 source "$DATADIR/bash-completion/bash_completion"
 
 COMP_LINE="$*"

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -u
-
 DATADIR="$(pkg-config --variable=datadir bash-completion)"
 
 source "$DATADIR/bash-completion/bash_completion"

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-source /usr/share/bash-completion/bash_completion
+DATADIR="$(pkg-config --variable=datadir bash-completion)"
+
+source "$DATADIR/bash-completion/bash_completion"
 
 COMP_LINE="$*"
 COMP_WORDS=("$@")

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -u
 
 DATADIR="$(pkg-config --variable=datadir bash-completion)"
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,8 @@
 import * as path from 'path'
 import * as TurndownService from 'turndown'
 import * as LSP from 'vscode-languageserver'
+import * as Process from 'child_process'
+import * as Path from 'path'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import Analyzer from './analyser'
@@ -117,6 +119,16 @@ export default class BashServer {
     params: LSP.ReferenceParams | LSP.TextDocumentPositionParams,
   ): string | null {
     return this.analyzer.wordAtPoint(
+      params.textDocument.uri,
+      params.position.line,
+      params.position.character,
+    )
+  }
+
+  private getCommandNameAtPoint(
+    params: LSP.ReferenceParams | LSP.TextDocumentPositionParams,
+  ): string | null {
+    return this.analyzer.commandNameAtPoint(
       params.textDocument.uri,
       params.position.line,
       params.position.character,
@@ -323,6 +335,22 @@ export default class BashServer {
       return []
     }
 
+    let options: string[] = []
+    if (word && word.startsWith('-')) {
+        const commandName = this.getCommandNameAtPoint({
+          ...params,
+          position: {
+            line: params.position.line,
+            // Go one character back to get completion on the current word
+            character: Math.max(params.position.character - 1, 0),
+          },
+        })
+
+        if(commandName) {
+            options = getCommandOptions(commandName, word)
+        }
+    }
+
     const currentUri = params.textDocument.uri
 
     // TODO: an improvement here would be to detect if the current word is
@@ -385,11 +413,21 @@ export default class BashServer {
       },
     }))
 
+    const optionsCompletions = options.map(option => ({
+      label: option,
+      kind: LSP.SymbolKind.Interface,
+      data: {
+        name: option,
+        type: CompletionItemDataType.Symbol
+      },
+    }))
+
     const allCompletions = [
       ...reservedWordsCompletions,
       ...symbolCompletions,
       ...programCompletions,
       ...builtinsCompletions,
+      ...optionsCompletions,
     ]
 
     if (word) {
@@ -531,3 +569,13 @@ const getMarkdownContent = (documentation: string): LSP.MarkupContent => ({
   // Passed as markdown for syntax highlighting
   kind: 'markdown' as const,
 })
+
+function getCommandOptions(name: string, word: string): string[] {
+    // TODO: The options could be cached.
+    const options = Process.spawnSync(
+        Path.join(__dirname, '../src/get-options.sh'),
+        [name, word]
+    )
+
+    return options.stdout.toString().split('\t')
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,8 +1,8 @@
+import * as Process from 'child_process'
 import * as path from 'path'
+import * as Path from 'path'
 import * as TurndownService from 'turndown'
 import * as LSP from 'vscode-languageserver'
-import * as Process from 'child_process'
-import * as Path from 'path'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import Analyzer from './analyser'
@@ -41,7 +41,7 @@ export default class BashServer {
     return Promise.all([
       Executables.fromPath(PATH),
       Analyzer.fromRoot({ connection, rootPath, parser }),
-    ]).then((xs) => {
+    ]).then(xs => {
       const executables = xs[0]
       const analyzer = xs[1]
       return new BashServer(connection, executables, analyzer)
@@ -72,7 +72,7 @@ export default class BashServer {
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
     this.documents.listen(this.connection)
-    this.documents.onDidChangeContent((change) => {
+    this.documents.onDidChangeContent(change => {
       const { uri } = change.document
       const diagnostics = this.analyzer.analyze(uri, change.document)
       if (config.getHighlightParsingError()) {
@@ -168,9 +168,8 @@ export default class BashServer {
           currentUri,
           symbolUri,
         )}${symbolDocumentation}`
-      : `${symbolKindToDescription(symbol.kind)} defined on line ${
-          symbolStarLine + 1
-        }${symbolDocumentation}`
+      : `${symbolKindToDescription(symbol.kind)} defined on line ${symbolStarLine +
+          1}${symbolDocumentation}`
   }
 
   private getCompletionItemsForSymbols({
@@ -258,7 +257,7 @@ export default class BashServer {
         currentUri,
       })
         // do not return hover referencing for the current line
-        .filter((symbol) => symbol.location.range.start.line !== params.position.line)
+        .filter(symbol => symbol.location.range.start.line !== params.position.line)
         .map((symbol: LSP.SymbolInformation) =>
           this.getDocumentationForSymbol({ currentUri, symbol }),
         )
@@ -302,7 +301,7 @@ export default class BashServer {
 
     return this.analyzer
       .findOccurrences(params.textDocument.uri, word)
-      .map((n) => ({ range: n.range }))
+      .map(n => ({ range: n.range }))
   }
 
   private onReferences(params: LSP.ReferenceParams): LSP.Location[] | null {
@@ -382,7 +381,7 @@ export default class BashServer {
       return symbolCompletions
     }
 
-    const reservedWordsCompletions = ReservedWords.LIST.map((reservedWord) => ({
+    const reservedWordsCompletions = ReservedWords.LIST.map(reservedWord => ({
       label: reservedWord,
       kind: LSP.SymbolKind.Interface, // ??
       data: {
@@ -393,8 +392,8 @@ export default class BashServer {
 
     const programCompletions = this.executables
       .list()
-      .filter((executable) => !Builtins.isBuiltin(executable))
-      .map((executable) => {
+      .filter(executable => !Builtins.isBuiltin(executable))
+      .map(executable => {
         return {
           label: executable,
           kind: LSP.SymbolKind.Function,
@@ -405,7 +404,7 @@ export default class BashServer {
         }
       })
 
-    const builtinsCompletions = Builtins.LIST.map((builtin) => ({
+    const builtinsCompletions = Builtins.LIST.map(builtin => ({
       label: builtin,
       kind: LSP.SymbolKind.Interface, // ??
       data: {
@@ -414,7 +413,7 @@ export default class BashServer {
       },
     }))
 
-    const optionsCompletions = options.map((option) => ({
+    const optionsCompletions = options.map(option => ({
       label: option,
       kind: LSP.SymbolKind.Interface,
       data: {
@@ -433,7 +432,7 @@ export default class BashServer {
 
     if (word) {
       // Filter to only return suffixes of the current word
-      return allCompletions.filter((item) => item.label.startsWith(word))
+      return allCompletions.filter(item => item.label.startsWith(word))
     }
 
     return allCompletions
@@ -486,15 +485,15 @@ function deduplicateSymbols({
 
   const getSymbolId = ({ name, kind }: LSP.SymbolInformation) => `${name}${kind}`
 
-  const symbolsCurrentFile = symbols.filter((s) => isCurrentFile(s))
+  const symbolsCurrentFile = symbols.filter(s => isCurrentFile(s))
 
   const symbolsOtherFiles = symbols
-    .filter((s) => !isCurrentFile(s))
+    .filter(s => !isCurrentFile(s))
     // Remove identical symbols matching current file
     .filter(
-      (symbolOtherFiles) =>
+      symbolOtherFiles =>
         !symbolsCurrentFile.some(
-          (symbolCurrentFile) =>
+          symbolCurrentFile =>
             getSymbolId(symbolCurrentFile) === getSymbolId(symbolOtherFiles),
         ),
     )

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -577,6 +577,10 @@ function getCommandOptions(name: string, word: string): string[] {
     word,
   ])
 
+  if (options.status !== 0) {
+    return []
+  }
+
   return options.stdout
     .toString()
     .split('\t')

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -41,7 +41,7 @@ export default class BashServer {
     return Promise.all([
       Executables.fromPath(PATH),
       Analyzer.fromRoot({ connection, rootPath, parser }),
-    ]).then(xs => {
+    ]).then((xs) => {
       const executables = xs[0]
       const analyzer = xs[1]
       return new BashServer(connection, executables, analyzer)
@@ -72,7 +72,7 @@ export default class BashServer {
     // The content of a text document has changed. This event is emitted
     // when the text document first opened or when its content has changed.
     this.documents.listen(this.connection)
-    this.documents.onDidChangeContent(change => {
+    this.documents.onDidChangeContent((change) => {
       const { uri } = change.document
       const diagnostics = this.analyzer.analyze(uri, change.document)
       if (config.getHighlightParsingError()) {
@@ -168,8 +168,9 @@ export default class BashServer {
           currentUri,
           symbolUri,
         )}${symbolDocumentation}`
-      : `${symbolKindToDescription(symbol.kind)} defined on line ${symbolStarLine +
-          1}${symbolDocumentation}`
+      : `${symbolKindToDescription(symbol.kind)} defined on line ${
+          symbolStarLine + 1
+        }${symbolDocumentation}`
   }
 
   private getCompletionItemsForSymbols({
@@ -257,7 +258,7 @@ export default class BashServer {
         currentUri,
       })
         // do not return hover referencing for the current line
-        .filter(symbol => symbol.location.range.start.line !== params.position.line)
+        .filter((symbol) => symbol.location.range.start.line !== params.position.line)
         .map((symbol: LSP.SymbolInformation) =>
           this.getDocumentationForSymbol({ currentUri, symbol }),
         )
@@ -301,7 +302,7 @@ export default class BashServer {
 
     return this.analyzer
       .findOccurrences(params.textDocument.uri, word)
-      .map(n => ({ range: n.range }))
+      .map((n) => ({ range: n.range }))
   }
 
   private onReferences(params: LSP.ReferenceParams): LSP.Location[] | null {
@@ -337,18 +338,18 @@ export default class BashServer {
 
     let options: string[] = []
     if (word && word.startsWith('-')) {
-        const commandName = this.getCommandNameAtPoint({
-          ...params,
-          position: {
-            line: params.position.line,
-            // Go one character back to get completion on the current word
-            character: Math.max(params.position.character - 1, 0),
-          },
-        })
+      const commandName = this.getCommandNameAtPoint({
+        ...params,
+        position: {
+          line: params.position.line,
+          // Go one character back to get completion on the current word
+          character: Math.max(params.position.character - 1, 0),
+        },
+      })
 
-        if(commandName) {
-            options = getCommandOptions(commandName, word)
-        }
+      if (commandName) {
+        options = getCommandOptions(commandName, word)
+      }
     }
 
     const currentUri = params.textDocument.uri
@@ -381,7 +382,7 @@ export default class BashServer {
       return symbolCompletions
     }
 
-    const reservedWordsCompletions = ReservedWords.LIST.map(reservedWord => ({
+    const reservedWordsCompletions = ReservedWords.LIST.map((reservedWord) => ({
       label: reservedWord,
       kind: LSP.SymbolKind.Interface, // ??
       data: {
@@ -392,8 +393,8 @@ export default class BashServer {
 
     const programCompletions = this.executables
       .list()
-      .filter(executable => !Builtins.isBuiltin(executable))
-      .map(executable => {
+      .filter((executable) => !Builtins.isBuiltin(executable))
+      .map((executable) => {
         return {
           label: executable,
           kind: LSP.SymbolKind.Function,
@@ -404,7 +405,7 @@ export default class BashServer {
         }
       })
 
-    const builtinsCompletions = Builtins.LIST.map(builtin => ({
+    const builtinsCompletions = Builtins.LIST.map((builtin) => ({
       label: builtin,
       kind: LSP.SymbolKind.Interface, // ??
       data: {
@@ -413,12 +414,12 @@ export default class BashServer {
       },
     }))
 
-    const optionsCompletions = options.map(option => ({
+    const optionsCompletions = options.map((option) => ({
       label: option,
       kind: LSP.SymbolKind.Interface,
       data: {
         name: option,
-        type: CompletionItemDataType.Symbol
+        type: CompletionItemDataType.Symbol,
       },
     }))
 
@@ -432,7 +433,7 @@ export default class BashServer {
 
     if (word) {
       // Filter to only return suffixes of the current word
-      return allCompletions.filter(item => item.label.startsWith(word))
+      return allCompletions.filter((item) => item.label.startsWith(word))
     }
 
     return allCompletions
@@ -485,15 +486,15 @@ function deduplicateSymbols({
 
   const getSymbolId = ({ name, kind }: LSP.SymbolInformation) => `${name}${kind}`
 
-  const symbolsCurrentFile = symbols.filter(s => isCurrentFile(s))
+  const symbolsCurrentFile = symbols.filter((s) => isCurrentFile(s))
 
   const symbolsOtherFiles = symbols
-    .filter(s => !isCurrentFile(s))
+    .filter((s) => !isCurrentFile(s))
     // Remove identical symbols matching current file
     .filter(
-      symbolOtherFiles =>
+      (symbolOtherFiles) =>
         !symbolsCurrentFile.some(
-          symbolCurrentFile =>
+          (symbolCurrentFile) =>
             getSymbolId(symbolCurrentFile) === getSymbolId(symbolOtherFiles),
         ),
     )
@@ -571,11 +572,11 @@ const getMarkdownContent = (documentation: string): LSP.MarkupContent => ({
 })
 
 function getCommandOptions(name: string, word: string): string[] {
-    // TODO: The options could be cached.
-    const options = Process.spawnSync(
-        Path.join(__dirname, '../src/get-options.sh'),
-        [name, word]
-    )
+  // TODO: The options could be cached.
+  const options = Process.spawnSync(Path.join(__dirname, '../src/get-options.sh'), [
+    name,
+    word,
+  ])
 
-    return options.stdout.toString().split('\t')
+  return options.stdout.toString().split('\t')
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -577,5 +577,9 @@ function getCommandOptions(name: string, word: string): string[] {
     word,
   ])
 
-  return options.stdout.toString().split('\t')
+  return options.stdout
+    .toString()
+    .split('\t')
+    .map(l => l.trim())
+    .filter(l => l.length > 0)
 }

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -21,6 +21,7 @@ export const FIXTURE_URI = {
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
   SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
   COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`,
+  OPTIONS: `file://${path.join(FIXTURE_FOLDER, 'options.sh')}`,
 }
 
 export const FIXTURE_DOCUMENT = {
@@ -30,6 +31,7 @@ export const FIXTURE_DOCUMENT = {
   PARSE_PROBLEMS: getDocument(FIXTURE_URI.PARSE_PROBLEMS),
   SOURCING: getDocument(FIXTURE_URI.SOURCING),
   COMMENT_DOC: getDocument(FIXTURE_URI.COMMENT_DOC),
+  OPTIONS: getDocument(FIXTURE_URI.OPTIONS),
 }
 
 export default FIXTURE_DOCUMENT

--- a/testing/fixtures/options.sh
+++ b/testing/fixtures/options.sh
@@ -1,0 +1,3 @@
+grep -
+grep --
+grep --line-


### PR DESCRIPTION
Closes #117.

https://user-images.githubusercontent.com/39320840/121274961-3a5e3e00-c891-11eb-881b-c85bdee29d10.mp4

In vim, `-` must be added to the keyword characters for this to work.
```vim
autocmd FileType sh set iskeyword+=45
```