### PR TITLE
Release vscode client to 1.12.0

### DIFF
--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -4,7 +4,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "publisher": "mads-hartmann",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We never release vscode client 1.12.0... 🙈

Thanks to @jonasbb for discovering this.

https://github.com/bash-lsp/bash-language-server/issues/328
