### PR TITLE
Adding Multiline Comments

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -247,6 +247,13 @@ describe('commentsAbove', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
     expect(analyzer.commentsAbove(CURRENT_URI, 42)).toEqual('works for variables')
   })
+
+  it('returns connected comments with empty comment line', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.COMMENT_DOC)
+    expect(analyzer.commentsAbove(CURRENT_URI, 51)).toEqual(
+      'this is also included\n\ndoc for func_four',
+    )
+  })
 })
 
 describe('fromRoot', () => {

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -438,7 +438,14 @@ export default class Analyzer {
       // this regexp has to be defined within the function
       const commentRegExp = /^\s*#\s*(.*)/g
       const matches = commentRegExp.exec(l)
-      return matches ? matches[1].trim() : null
+      if (!matches) {
+        return null
+      }
+      let retVal = matches[1].trim()
+      if (retVal == '') {
+        retVal = ' '
+      }
+      return retVal
     }
 
     let currentLine = doc.getText({
@@ -450,6 +457,10 @@ export default class Analyzer {
     // the current line until getComment returns null
     let currentComment: string | null = ''
     while ((currentComment = getComment(currentLine))) {
+      if (currentComment == ' ') {
+        currentComment = ''
+      }
+
       commentBlock.push(currentComment)
       commentBlockIndex -= 1
       currentLine = doc.getText({

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -450,10 +450,6 @@ export default class Analyzer {
     // the current line until getComment returns null
     let currentComment: string | null = ''
     while ((currentComment = getComment(currentLine)) !== null) {
-      if (currentComment == ' ') {
-        currentComment = ''
-      }
-
       commentBlock.push(currentComment)
       commentBlockIndex -= 1
       currentLine = doc.getText({

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -438,14 +438,7 @@ export default class Analyzer {
       // this regexp has to be defined within the function
       const commentRegExp = /^\s*#\s*(.*)/g
       const matches = commentRegExp.exec(l)
-      if (!matches) {
-        return null
-      }
-      let retVal = matches[1].trim()
-      if (retVal == '') {
-        retVal = ' '
-      }
-      return retVal
+      return matches ? matches[1].trim() : null
     }
 
     let currentLine = doc.getText({
@@ -456,7 +449,7 @@ export default class Analyzer {
     // iterate on every line above and including
     // the current line until getComment returns null
     let currentComment: string | null = ''
-    while ((currentComment = getComment(currentLine))) {
+    while ((currentComment = getComment(currentLine)) !== null) {
       if (currentComment == ' ') {
         currentComment = ''
       }

--- a/testing/fixtures/comment-doc-on-hover.sh
+++ b/testing/fixtures/comment-doc-on-hover.sh
@@ -45,3 +45,10 @@ my_var="pizza"
 
 my_other_var="no comments above me :("
 
+
+# this is also included
+#
+# doc for func_four
+func_four() {
+    echo "func_four"
+}


### PR DESCRIPTION
The overlay should be able to display comments that belong together,
even when an empty comment line is in between, e.g.

    # foo
    #
    # bar

should be allowed and this patch enables this.

(may solve #347)