### PR TITLE
Workaround for node 18 support

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 3.0.3
+
+- Workaround for emscripten node 18 support https://github.com/bash-lsp/bash-language-server/pull/404
+
 ## 3.0.2
 
 - Fix analyzer not being called when getHighlightParsingError is off https://github.com/bash-lsp/bash-language-server/pull/396

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -1,6 +1,15 @@
 import * as Parser from 'web-tree-sitter'
 
+const _global: any = global
+
 export async function initializeParser(): Promise<Parser> {
+  if (_global.fetch) {
+    // NOTE: temporary workaround for emscripten node 18 support.
+    // emscripten is used for compiling tree-sitter to wasm.
+    // https://github.com/emscripten-core/emscripten/issues/16915
+    delete _global.fetch
+  }
+
   await Parser.init()
   const parser = new Parser()
 


### PR DESCRIPTION
I've looked into the issue behind  #353 and the node.js support for `fetch` conflicts with some of the wasm code generated by [emscripten](https://github.com/emscripten-core/emscripten/blob/29999a7115cfdb3e8c6cc9dca89c87af436f03c3/src/source_map_support.js#L113) – a [downstream fix is here](https://github.com/emscripten-core/emscripten/pull/16917) and [issue here](https://github.com/emscripten-core/emscripten/issues/16915).

I've validated this by disabling fetch using `--no-experimental-fetch` when running test:
```bash
node --no-experimental-fetch  node_modules/.bin/jest server/src/__tests__/server.test.ts
```

This PR patches the node global environment to work around this. This should be safe as only the language server should be running in the same process.