### PR TITLE
Fix file uri under Windows are incorrect

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 3.0.4
+
+- Fix Windows support for analyzer https://github.com/bash-lsp/bash-language-server/pull/433
+
 ## 3.0.3
 
 - Workaround for emscripten node 18 support https://github.com/bash-lsp/bash-language-server/pull/404

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as FuzzySearch from 'fuzzy-search'
 import * as request from 'request-promise-native'
 import * as URI from 'urijs'
+import * as url from 'url'
 import { promisify } from 'util'
 import * as LSP from 'vscode-languageserver'
 import * as Parser from 'web-tree-sitter'
@@ -72,7 +73,7 @@ export default class Analyzer {
       )
 
       for (const filePath of filePaths) {
-        const uri = `file://${filePath}`
+        const uri = url.pathToFileURL(filePath).href
         connection.console.log(`Analyzing ${uri}`)
 
         try {


### PR DESCRIPTION
https://en.wikipedia.org/wiki/File_URI_scheme#Windows_2

You can't just prefix it with "file://".
Under Windows, that means it's a network location.

Let's just uses Node's API to do a proper conversion.

https://nodejs.org/api/url.html#urlpathtofileurlpath

Signed-off-by: Jack Cherng <jfcherng@gmail.com>