### PR TITLE
CVE-2022-0613: Update urijs to v1.19.11

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "turndown": "^7.0.0",
-    "urijs": "^1.19.1",
+    "urijs": "^1.19.11",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
     "web-tree-sitter": "^0.20.5"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -489,7 +489,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-urijs@^1.19.1:
+urijs@^1.19.11:
   version "1.19.11"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
   integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==


### PR DESCRIPTION
There is a Authorization Bypass Through User-Controlled Key in NPM
urijs prior to 1.19.8.