### PR TITLE
Add 'bash' file types to vim-lsp allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ if executable('bash-language-server')
   au User lsp_setup call lsp#register_server({
         \ 'name': 'bash-language-server',
         \ 'cmd': {server_info->[&shell, &shellcmdflag, 'bash-language-server start']},
-        \ 'allowlist': ['sh'],
+        \ 'allowlist': ['sh', 'bash'],
         \ })
 endif
 ```


### PR DESCRIPTION
Files may be identified either as `sh` or `bash` with modelines, this helps ensure consistent usage

_Note_: A similar approach may be useful/viable for other configurations, I'm only noting what I can actually test 😄