### PR TITLE
Add "--shell=bash" argument for ShellCheck

### DIFF
--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -62,7 +62,7 @@ export default class Linter {
     document: LSP.TextDocument,
     folders: LSP.WorkspaceFolder[],
   ): Promise<ShellcheckResult> {
-    const args = ['--format=json1', '--external-sources', `--source-path=${this.cwd}`]
+    const args = ['--shell=bash', '--format=json1', '--external-sources', `--source-path=${this.cwd}`]
     for (const folder of folders) {
       args.push(`--source-path=${folder.name}`)
     }

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -62,7 +62,12 @@ export default class Linter {
     document: LSP.TextDocument,
     folders: LSP.WorkspaceFolder[],
   ): Promise<ShellcheckResult> {
-    const args = ['--shell=bash', '--format=json1', '--external-sources', `--source-path=${this.cwd}`]
+    const args = [
+      '--shell=bash',
+      '--format=json1',
+      '--external-sources',
+      `--source-path=${this.cwd}`,
+    ]
     for (const folder of folders) {
       args.push(`--source-path=${folder.name}`)
     }


### PR DESCRIPTION
This PR adds the argument `--shell=bash` when invoking ShellCheck to improve robustness when you don't have a shebang or file extension that ShellCheck can use to determine the shell type. In particular, ShellCheck doesn't automatically assume `.sh` corresponds to Bash, which can lead to getting [SC2148](https://www.shellcheck.net/wiki/SC2148).

Since this language server is Bash-only, I figure it makes sense to always run ShellCheck in this mode.