### PR TITLE
shellcheck: fix vscode config and default to executable found on path

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bash Language Server
 
+## 3.2.0
+
+- Dependency upgrades
+- Default to shellcheck binary found on path https://github.com/bash-lsp/bash-language-server/pull/555
+
 ## 3.1.1
 
 - Dependency upgrades

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/linter.test.ts
+++ b/server/src/__tests__/linter.test.ts
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as LSP from 'vscode-languageserver'
 
 import { FIXTURE_DOCUMENT, FIXTURE_FOLDER } from '../../../testing/fixtures'
-import Linter, { assertShellcheckResult } from '../linter'
+import { assertShellcheckResult, Linter } from '../linter'
 
 function textToDoc(txt: string) {
   return LSP.TextDocument.create('foo', 'bar', 0, txt)

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,6 +1,9 @@
 import { spawn } from 'child_process'
 import * as LSP from 'vscode-languageserver'
 
+import * as config from './config'
+import { execShellScript } from './util/sh'
+
 function formatMessage(comment: ShellcheckComment): string {
   return (comment.code ? `SC${comment.code}: ` : '') + comment.message
 }
@@ -10,8 +13,23 @@ type LinterOptions = {
   cwd?: string
 }
 
-export default class Linter {
-  private executablePath: string | null
+export async function getLinterExecutablePath(): Promise<string | null> {
+  const pathFromConfig = config.getShellcheckPath()
+
+  if (pathFromConfig) {
+    return pathFromConfig
+  }
+
+  try {
+    const path = (await execShellScript('which shellcheck')).trim()
+    return path === '' ? null : path
+  } catch (e) {
+    return null
+  }
+}
+
+export class Linter {
+  public executablePath: string | null
   private cwd: string
   _canLint: boolean
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,7 +8,7 @@ import Analyzer from './analyser'
 import * as Builtins from './builtins'
 import * as config from './config'
 import Executables from './executables'
-import Linter from './linter'
+import { getLinterExecutablePath, Linter } from './linter'
 import { initializeParser } from './parser'
 import * as ReservedWords from './reservedWords'
 import { BashCompletionItem, CompletionItemDataType } from './types'
@@ -41,8 +41,9 @@ export default class BashServer {
     return Promise.all([
       Executables.fromPath(PATH),
       Analyzer.fromRoot({ connection, rootPath, parser }),
-      new Linter({ executablePath: config.getShellcheckPath() }),
-    ]).then(([executables, analyzer, linter]) => {
+      getLinterExecutablePath(),
+    ]).then(([executables, analyzer, linterExecutablePath]) => {
+      const linter = new Linter({ executablePath: linterExecutablePath })
       return new BashServer(connection, executables, analyzer, linter, capabilities)
     })
   }

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -29,7 +29,7 @@ export function execShellScript(body: string, cmd = 'bash'): Promise<string> {
 
 // Currently only reserved words where documentation doesn't make sense.
 // At least on OS X these just return the builtin man. On ubuntu there
-// are no documentaiton for them.
+// are no documentation for them.
 const WORDS_WITHOUT_DOCUMENTATION = new Set([
   'else',
   'fi',

--- a/vscode-client/README.md
+++ b/vscode-client/README.md
@@ -1,6 +1,10 @@
 # Bash IDE
 
-Visual Studio Code extension utilizing the [bash language server](bash-lsp), that is based on [Tree Sitter][tree-sitter] and its [grammar for Bash][tree-sitter-bash] and and supports [explainshell][explainshell] and [shellcheck][shellcheck].
+[![VS Marketplace installs](https://badgen.net/vs-marketplace/i/mads-hartmann.bash-ide-vscode?label=VS%20Marketplace%20installs)](https://marketplace.visualstudio.com/items?itemName=mads-hartmann.bash-ide-vscode)
+[![VS Marketplace downloads](https://badgen.net/vs-marketplace/d/mads-hartmann.bash-ide-vscode?label=VS%20Marketplace%20downloads)](https://marketplace.visualstudio.com/items?itemName=mads-hartmann.bash-ide-vscode)
+[![Open VSX downloads](https://badgen.net/open-vsx/d/mads-hartmann/bash-ide-vscode?color=purple&label=Open%20VSX%20downloads)](https://open-vsx.org/extension/mads-hartmann/bash-ide-vscode)
+
+Visual Studio Code extension utilizing the [Bash Language Server](bash-lsp) and integrates with [explainshell][explainshell] and [shellcheck][shellcheck].
 
 We strongly recommend that you install [shellcheck][shellcheck] to enable linting: https://github.com/koalaman/shellcheck#installing
 

--- a/vscode-client/README.md
+++ b/vscode-client/README.md
@@ -1,6 +1,8 @@
 # Bash IDE
 
-Visual Studio Code extension utilizing the [bash language server](bash-lsp), that is based on [Tree Sitter][tree-sitter] and its [grammar for Bash][tree-sitter-bash] and supports [explainshell][explainshell] integration.
+Visual Studio Code extension utilizing the [bash language server](bash-lsp), that is based on [Tree Sitter][tree-sitter] and its [grammar for Bash][tree-sitter-bash] and and supports [explainshell][explainshell] and [shellcheck][shellcheck].
+
+We strongly recommend that you install [shellcheck][shellcheck] to enable linting: https://github.com/koalaman/shellcheck#installing
 
 ## Features
 
@@ -28,3 +30,4 @@ For security reasons, it defaults to `""`, which disables explainshell integrati
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter
 [tree-sitter-bash]: https://github.com/tree-sitter/tree-sitter-bash
 [explainshell]: https://explainshell.com/
+[shellcheck]: https://www.shellcheck.net/

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -45,6 +45,11 @@
           "type": "string",
           "default": "",
           "description": "Configure explainshell server in order to get hover documentation on flags and options."
+        },
+        "bashIde.shellcheckPath": {
+          "type": "string",
+          "default": "",
+          "description": "Configure a custom path for the Shellcheck executable in order to get linting information."
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/bash-lsp/bash-language-server/issues/554