### PR TITLE
fix: default shell on Windows should be cmd.exe

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
     "urijs": "^1.19.11",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "web-tree-sitter": "^0.20.5"
+    "web-tree-sitter": "^0.20.5",
+    "which": "^2.0.2"
   },
   "scripts": {
     "prepublishOnly": "cd ../ && yarn run compile"
@@ -36,6 +37,7 @@
     "@types/glob": "8.0.0",
     "@types/request-promise-native": "1.0.18",
     "@types/turndown": "5.0.1",
-    "@types/urijs": "1.19.19"
+    "@types/urijs": "1.19.19",
+    "@types/which": "2.0.1"
   }
 }

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'child_process'
 import * as LSP from 'vscode-languageserver'
+import which = require('which')
 
 import * as config from './config'
-import { execShellScript } from './util/sh'
 
 function formatMessage(comment: ShellcheckComment): string {
   return (comment.code ? `SC${comment.code}: ` : '') + comment.message
@@ -14,18 +14,7 @@ type LinterOptions = {
 }
 
 export async function getLinterExecutablePath(): Promise<string | null> {
-  const pathFromConfig = config.getShellcheckPath()
-
-  if (pathFromConfig) {
-    return pathFromConfig
-  }
-
-  try {
-    const path = (await execShellScript('which shellcheck')).trim()
-    return path === '' ? null : path
-  } catch (e) {
-    return null
-  }
+  return config.getShellcheckPath() || (await which('shellcheck'))
 }
 
 export class Linter {

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -3,9 +3,19 @@ import * as ChildProcess from 'child_process'
 /**
  * Execute the following sh program.
  */
-export function execShellScript(body: string, cmd = 'bash'): Promise<string> {
-  const args = ['-c', body]
-  const process = ChildProcess.spawn(cmd, args)
+export function execShellScript(
+  body: string,
+  cmd = process.platform === 'win32' ? 'cmd.exe' : 'bash',
+): Promise<string> {
+  const args = []
+
+  if (cmd === 'cmd.exe') {
+    args.push('/c', body)
+  } else {
+    args.push('-c', body)
+  }
+
+  const proc = ChildProcess.spawn(cmd, args)
 
   return new Promise((resolve, reject) => {
     let output = ''
@@ -18,12 +28,12 @@ export function execShellScript(body: string, cmd = 'bash'): Promise<string> {
       }
     }
 
-    process.stdout.on('data', (buffer) => {
+    proc.stdout.on('data', (buffer) => {
       output += buffer
     })
 
-    process.on('close', handleClose)
-    process.on('error', handleClose)
+    proc.on('close', handleClose)
+    proc.on('error', handleClose)
   })
 }
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -62,6 +62,11 @@
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
   integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
 
+"@types/which@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.1.tgz#27ecd67f915b7c3d6ba552135bb1eecd66e63501"
+  integrity sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==
+
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -285,6 +290,11 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -542,6 +552,13 @@ web-tree-sitter@^0.20.5:
   version "0.20.5"
   resolved "https://registry.yarnpkg.com/web-tree-sitter/-/web-tree-sitter-0.20.5.tgz#62c8ea29d94f6ef6f03ce9c68c860df011ee26c7"
   integrity sha512-mpXlqIeEBE5Q71cnBnt8w6XKhIiKmllPECqsIFBtMvzcfCxA8+614iyMJXBCQo95Vs3y1zORLqiLJn25pYZ4Tw==
+
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -58,7 +58,7 @@
     "vscode:prepublish": "cd .. && yarn run compile"
   },
   "dependencies": {
-    "bash-language-server": "3.2.0",
+    "bash-language-server": "3.2.1",
     "vscode-languageclient": "^6.1.3",
     "vscode-languageserver": "^6.1.1"
   },

--- a/vscode-client/yarn.lock
+++ b/vscode-client/yarn.lock
@@ -42,10 +42,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-bash-language-server@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/bash-language-server/-/bash-language-server-3.2.0.tgz#31e1dd2190d561aa42cf4829103c579e70f55c03"
-  integrity sha512-lk9av+yLeOQdao8rzSCr0BNYnghK4HIHeX21xpp+1lBsEAYWWuI+7jF1xVF6SZnAmZKDc2DlOLCl0u5GCD2T+A==
+bash-language-server@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/bash-language-server/-/bash-language-server-3.2.1.tgz#d11eff53aaec4252cf8a3ef1bf73c9454dc77648"
+  integrity sha512-4e4uxJVuczVn8lv9i4L/XMtmqkRzXFg/ms+FpMWDMQOMY2N6UOze1AsT5y++CnMDHvvh2rFcHORUUy8wRAPP/g==
   dependencies:
     fuzzy-search "^3.2.1"
     glob "^8.0.0"


### PR DESCRIPTION
As of `server-3.2.0`, there is auto detection for `shellcheck` executable.

https://github.com/bash-lsp/bash-language-server/blob/fa9120c3b37d19c285fa91d99831231c88b6a874/server/src/linter.ts#L24 

But it uses `bash` by default.

---

But `which` is not available under Windows `cmd.exe`. A proper functionality fix would be a cross-platform solution like [node-which](https://www.npmjs.com/package/which). If we don't want to do this part, I can revert it. 