### PR TITLE
Fix auto detection for path of `shellcheck.exe` on Windows

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
     "urijs": "^1.19.11",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "web-tree-sitter": "^0.20.5"
+    "web-tree-sitter": "^0.20.5",
+    "which": "^2.0.2"
   },
   "scripts": {
     "prepublishOnly": "cd ../ && yarn run compile"
@@ -35,6 +36,7 @@
     "@types/fuzzy-search": "2.1.2",
     "@types/glob": "8.0.0",
     "@types/turndown": "5.0.1",
-    "@types/urijs": "1.19.19"
+    "@types/urijs": "1.19.19",
+    "@types/which": "2.0.1"
   }
 }

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'child_process'
 import * as LSP from 'vscode-languageserver'
+import which = require('which')
 
 import * as config from './config'
-import { execShellScript } from './util/sh'
 
 function formatMessage(comment: ShellcheckComment): string {
   return (comment.code ? `SC${comment.code}: ` : '') + comment.message
@@ -14,18 +14,7 @@ type LinterOptions = {
 }
 
 export async function getLinterExecutablePath(): Promise<string | null> {
-  const pathFromConfig = config.getShellcheckPath()
-
-  if (pathFromConfig) {
-    return pathFromConfig
-  }
-
-  try {
-    const path = (await execShellScript('which shellcheck')).trim()
-    return path === '' ? null : path
-  } catch (e) {
-    return null
-  }
+  return config.getShellcheckPath() || (await which('shellcheck'))
 }
 
 export class Linter {

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -1,10 +1,22 @@
 import * as ChildProcess from 'child_process'
 
+import { isWindows } from './platform'
+
 /**
  * Execute the following sh program.
  */
-export function execShellScript(body: string, cmd = 'bash'): Promise<string> {
-  const args = ['-c', body]
+export function execShellScript(
+  body: string,
+  cmd = isWindows() ? 'cmd.exe' : 'bash',
+): Promise<string> {
+  const args = []
+
+  if (cmd === 'cmd.exe') {
+    args.push('/c', body)
+  } else {
+    args.push('-c', body)
+  }
+
   const process = ChildProcess.spawn(cmd, args)
 
   return new Promise((resolve, reject) => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -43,6 +43,11 @@
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
   integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
 
+"@types/which@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.1.tgz#27ecd67f915b7c3d6ba552135bb1eecd66e63501"
+  integrity sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -120,6 +125,11 @@ inherits@2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -223,6 +233,13 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
# Issues

- There is no `bash`/`which` on Windows, by default.
- Even if using the `bash`/`which` from git-bash or WSL, the returned path is Unix-style. And Node.js on Windows is not happy with it.

# Solutions

- Use `cmd.exe` as the default shell on Windows.
- Use the `which` package to find `shellcheck` in a cross-platform way.