### PR TITLE
Performant globbing and background analysis

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@types/node-fetch": "2.6.2",
+    "fast-glob": "3.2.12",
     "fuzzy-search": "^3.2.1",
-    "glob": "^8.0.0",
     "node-fetch": "^2.6.7",
     "turndown": "^7.0.0",
     "urijs": "^1.19.11",

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -20,6 +20,12 @@ async function initializeServer() {
     workspaceFolders: null,
   })
 
+  const { backgroundAnalysisCompleted } = server
+
+  if (backgroundAnalysisCompleted) {
+    await backgroundAnalysisCompleted
+  }
+
   return {
     connection,
     console,

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -7,7 +7,7 @@ import { promisify } from 'util'
 import * as LSP from 'vscode-languageserver'
 import * as Parser from 'web-tree-sitter'
 
-import { getGlobPattern } from './config'
+import * as config from './config'
 import { flattenArray, flattenObjectValues } from './util/flatten'
 import { getFilePaths } from './util/fs'
 import { getShebang, isBashShebang } from './util/shebang'
@@ -84,7 +84,8 @@ export default class Analyzer {
     connection: LSP.Connection
     rootPath: string
   }) {
-    const globPattern = getGlobPattern()
+    const globPattern = config.getGlobPattern()
+    const backgroundAnalysisMaxFiles = config.getBackgroundAnalysisMaxFiles()
     connection.console.log(
       `BackgroundAnalysis: resolving glob "${globPattern}" inside "${rootPath}"...`,
     )
@@ -97,6 +98,7 @@ export default class Analyzer {
       filePaths = await getFilePaths({
         globPattern,
         rootPath,
+        maxItems: backgroundAnalysisMaxFiles,
       })
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : error

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_GLOB_PATTERN = '**/*@(.sh|.inc|.bash|.command)'
-export const DEFAULT_BACKGROUND_ANALYSIS_MAX_FILES = 5000
+export const DEFAULT_BACKGROUND_ANALYSIS_MAX_FILES = 500
 
 export function getShellcheckPath(): string | null {
   const { SHELLCHECK_PATH } = process.env

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_GLOB_PATTERN = '**/*@(.sh|.inc|.bash|.command)'
+export const DEFAULT_BACKGROUND_ANALYSIS_MAX_FILES = 5000
 
 export function getShellcheckPath(): string | null {
   const { SHELLCHECK_PATH } = process.env
@@ -25,4 +26,10 @@ export function getHighlightParsingError(): boolean {
   return typeof HIGHLIGHT_PARSING_ERRORS !== 'undefined'
     ? HIGHLIGHT_PARSING_ERRORS === 'true' || HIGHLIGHT_PARSING_ERRORS === '1'
     : false
+}
+
+export function getBackgroundAnalysisMaxFiles(): number {
+  const { BACKGROUND_ANALYSIS_MAX_FILES } = process.env
+  const parsed = parseInt(BACKGROUND_ANALYSIS_MAX_FILES || '', 10)
+  return !isNaN(parsed) ? parsed : DEFAULT_BACKGROUND_ANALYSIS_MAX_FILES
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -14,6 +14,9 @@ export function getExplainshellEndpoint(): string | null {
     : null
 }
 
+/**
+ * Get the glob pattern for files to run background analysis on.
+ */
 export function getGlobPattern(): string {
   const { GLOB_PATTERN } = process.env
   return typeof GLOB_PATTERN === 'string' && GLOB_PATTERN.trim() !== ''
@@ -28,6 +31,9 @@ export function getHighlightParsingError(): boolean {
     : false
 }
 
+/**
+ * Get the maximum number of files to run background analysis on.
+ */
 export function getBackgroundAnalysisMaxFiles(): number {
   const { BACKGROUND_ANALYSIS_MAX_FILES } = process.env
   const parsed = parseInt(BACKGROUND_ANALYSIS_MAX_FILES || '', 10)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -38,14 +38,14 @@ export default class BashServer {
       throw new Error('Expected PATH environment variable to be set')
     }
 
-    return Promise.all([
-      Executables.fromPath(PATH),
-      Analyzer.fromRoot({ connection, rootPath, parser }),
-      getLinterExecutablePath(),
-    ]).then(([executables, analyzer, linterExecutablePath]) => {
-      const linter = new Linter({ executablePath: linterExecutablePath })
-      return new BashServer(connection, executables, analyzer, linter, capabilities)
-    })
+    const analyzer = Analyzer.fromRoot({ connection, rootPath, parser })
+
+    return Promise.all([Executables.fromPath(PATH), getLinterExecutablePath()]).then(
+      ([executables, linterExecutablePath]) => {
+        const linter = new Linter({ executablePath: linterExecutablePath })
+        return new BashServer(connection, executables, analyzer, linter, capabilities)
+      },
+    )
   }
 
   private executables: Executables

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -38,12 +38,25 @@ export default class BashServer {
       throw new Error('Expected PATH environment variable to be set')
     }
 
-    const analyzer = Analyzer.fromRoot({ connection, rootPath, parser })
-
     return Promise.all([Executables.fromPath(PATH), getLinterExecutablePath()]).then(
       ([executables, linterExecutablePath]) => {
+        const analyzer = new Analyzer({ console: connection.console, parser })
         const linter = new Linter({ executablePath: linterExecutablePath })
-        return new BashServer(connection, executables, analyzer, linter, capabilities)
+
+        let backgroundAnalysisCompleted
+        if (rootPath) {
+          // NOTE: we do not block the server initialization on this background analysis.
+          backgroundAnalysisCompleted = analyzer.initiateBackgroundAnalysis({ rootPath })
+        }
+
+        return new BashServer({
+          analyzer,
+          backgroundAnalysisCompleted,
+          capabilities,
+          connection,
+          executables,
+          linter,
+        })
       },
     )
   }
@@ -55,19 +68,29 @@ export default class BashServer {
   private documents: LSP.TextDocuments<TextDocument> = new LSP.TextDocuments(TextDocument)
   private connection: LSP.Connection
   private clientCapabilities: LSP.ClientCapabilities
+  public backgroundAnalysisCompleted?: Promise<any>
 
-  private constructor(
-    connection: LSP.Connection,
-    executables: Executables,
-    analyzer: Analyzer,
-    linter: Linter,
-    capabilities: LSP.ClientCapabilities,
-  ) {
+  private constructor({
+    connection,
+    executables,
+    analyzer,
+    linter,
+    capabilities,
+    backgroundAnalysisCompleted,
+  }: {
+    connection: LSP.Connection
+    executables: Executables
+    analyzer: Analyzer
+    linter: Linter
+    capabilities: LSP.ClientCapabilities
+    backgroundAnalysisCompleted?: Promise<any>
+  }) {
     this.connection = connection
     this.executables = executables
     this.analyzer = analyzer
     this.linter = linter
     this.clientCapabilities = capabilities
+    this.backgroundAnalysisCompleted = backgroundAnalysisCompleted
   }
 
   /**

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -1,9 +1,9 @@
-import * as glob from 'glob'
-import * as Os from 'os'
+import * as fastGlob from 'fast-glob'
+import * as os from 'os'
 
 // from https://github.com/sindresorhus/untildify/blob/f85a087418aeaa2beb56fe2684fe3b64fc8c588d/index.js#L11
 export function untildify(pathWithTilde: string): string {
-  const homeDirectory = Os.homedir()
+  const homeDirectory = os.homedir()
   return homeDirectory
     ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
     : pathWithTilde
@@ -12,21 +12,33 @@ export function untildify(pathWithTilde: string): string {
 export async function getFilePaths({
   globPattern,
   rootPath,
+  maxItems,
 }: {
   globPattern: string
   rootPath: string
+  maxItems: number
 }): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    glob(
-      globPattern,
-      { cwd: rootPath, nodir: true, absolute: true, strict: false },
-      function (err, files) {
-        if (err) {
-          return reject(err)
-        }
-
-        resolve(files)
-      },
-    )
+  const stream = fastGlob.stream([globPattern], {
+    absolute: true,
+    onlyFiles: true,
+    cwd: rootPath,
+    followSymbolicLinks: true,
+    suppressErrors: true,
   })
+
+  // NOTE: we use a stream here to not block the event loop
+  // and ensure that we stop reading files if the glob returns
+  // too many files.
+  const files = []
+  let i = 0
+  for await (const fileEntry of stream) {
+    if (i >= maxItems) {
+      break
+    }
+
+    files.push(fileEntry.toString())
+    i++
+  }
+
+  return files
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2,6 +2,27 @@
 # yarn lockfile v1
 
 
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
+
 "@types/fuzzy-search@2.1.2":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/@types/fuzzy-search/-/fuzzy-search-2.1.2.tgz#d57b2af8fb723baa1792d40d511f431c4c8f75af"
@@ -53,17 +74,12 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+braces@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
-    balanced-match "^1.0.0"
+    fill-range "^7.0.1"
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -82,6 +98,31 @@ domino@^2.1.6:
   resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
   integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
 
+fast-glob@3.2.12:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fastq@^1.6.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
+  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  dependencies:
+    reusify "^1.0.4"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
@@ -91,45 +132,52 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
-
 fuzzy-search@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.2.1.tgz#65d5faad6bc633aee86f1898b7788dfe312ac6c9"
   integrity sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg==
 
-glob@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.0.1.tgz#00308f5c035aa0b2a447cd37ead267ddff1577d3"
-  integrity sha512-cF7FYZZ47YzmCu7dDy50xSRRfO3ErRfrXuLZcNIuyiJEco0XSrGtuilG19L5xp3NcwTx7Gn+X6Tv3fmsUPTbow==
+glob-parent@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
+    is-glob "^4.0.1"
 
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-glob@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
-    once "^1.3.0"
-    wrappy "1"
+    is-extglob "^2.1.1"
 
-inherits@2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -143,13 +191,6 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-minimatch@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
-  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
@@ -157,17 +198,34 @@ node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  dependencies:
-    wrappy "1"
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -240,8 +298,3 @@ which@^2.0.2:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=

--- a/vscode-client/yarn.lock
+++ b/vscode-client/yarn.lock
@@ -15,7 +15,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
-"@types/vscode@1.73.1":
+"@types/vscode@^1.44.0":
   version "1.73.1"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.73.1.tgz#f2b198dca65c693c4570475aca04a34ad773609d"
   integrity sha512-eArfOrAoZVV+Ao9zQOCaFNaeXj4kTCD+bGS2gyNgIFZH9xVMuLMlRrEkhb22NyxycFWKV1UyTh03vhaVHmqVMg==


### PR DESCRIPTION
When the server boots up we analyze all files matching a glob (default to `**/*@(.sh|.inc|.bash|.command)'`) from the given `rootPath`. We do this in order to enable features across files (e.g. jump to definition). The current setup works okay for smaller workspaces, but doesn't perform well the `rootPath` contains too many files. Problems observed:
- globbing (currently using `node-glob`) can take a very long time to complete!
- we block the LSP server initialisation so the server doesn't respond to other requests
- we can run out of memory and thereby crash the server

This should be fixed in this PR that:
1) switches the globbing library to [`fast-glob`](https://github.com/mrmlnc/fast-glob) which is a lot faster. Quick benchmarks shows the initial glob resolution to be 10X faster and I didn't find any issues compared to last time this was tried out (https://github.com/bash-lsp/bash-language-server/pull/113)
2) limit the amount of bash files we analyse in the background. This is configurable, but defaults to the first 5000 files matching the glob. The background analysis for 500 files takes around 3 seconds to analyze on my machine.
3) we now initialize the server before starting the background parsing

The usefulness of the background analysis for 500 files might be questionable, but the performance is decent IMO. With [Sourcing aware symbols completion and jump to definition](#244) this will become more interesting.

Resolves https://github.com/bash-lsp/bash-language-server/issues/301 
Might solve https://github.com/bash-lsp/bash-language-server/issues/317, https://github.com/bash-lsp/bash-language-server/issues/316 https://github.com/bash-lsp/bash-language-server/issues/277