### PR TITLE
Fix ShellCheck config

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -26,8 +26,7 @@
     "urijs": "^1.19.11",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
-    "web-tree-sitter": "^0.20.5",
-    "which": "^2.0.2"
+    "web-tree-sitter": "^0.20.5"
   },
   "scripts": {
     "prepublishOnly": "cd ../ && yarn run compile"

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -103,7 +103,7 @@ export class Linter {
       if ((e as any).code === 'ENOENT') {
         // shellcheck path wasn't found, don't try to lint any more:
         this.console.warn(
-          `ShellCheck: disabling linting as no executable '${this.executablePath}'`,
+          `ShellCheck: disabling linting as no executable was found at path '${this.executablePath}'`,
         )
         this._canLint = false
         return { comments: [] }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -161,11 +161,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
 merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -291,10 +286,3 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
-
-which@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -34,7 +34,7 @@
         "bashIde.globPattern": {
           "type": "string",
           "default": "**/*@(.sh|.inc|.bash|.command)",
-          "description": "Glob pattern for finding and parsing shell script files."
+          "description": "Glob pattern for finding and parsing shell script files in the workspace."
         },
         "bashIde.highlightParsingErrors": {
           "type": "boolean",
@@ -44,12 +44,12 @@
         "bashIde.explainshellEndpoint": {
           "type": "string",
           "default": "",
-          "description": "Configure explainshell server in order to get hover documentation on flags and options."
+          "description": "Configure explainshell server endpoint in order to get hover documentation on flags and options."
         },
         "bashIde.shellcheckPath": {
           "type": "string",
-          "default": "",
-          "description": "Configure a custom path for the Shellcheck executable in order to get linting information."
+          "default": "shellcheck",
+          "description": "Controls the executable used for ShellCheck linting information. An empty string will disable linting."
         }
       }
     }


### PR DESCRIPTION
Solves https://github.com/bash-lsp/bash-language-server/issues/570


https://github.com/bash-lsp/bash-language-server/pull/555 https://github.com/bash-lsp/bash-language-server/pull/563 introduced an unwanted side effect that you cannot disable ShellCheck from the configuration.

So we have a few different use cases here:
1) being able to disable shellcheck linting
2) being able to provide a custom path for shellcheck
3) default behaviour of the shellcheck integration working if shellcheck is found on the path

Defaulting the configuration to "shellcheck" and making an empty string disable it solves the different needs.

And we don't need the `which` library as the ShellCheck integration will just try linting once using the provided executable – if it fails we don't lint again.
