### PR TITLE
Fix shell documentation for newlines

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -37,15 +37,15 @@ describe('analyze', () => {
 })
 
 describe('findDefinition', () => {
-  it('returns empty list if parameter is not found', () => {
+  it('returns an empty list if word is not found', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
-    const result = analyzer.findDefinition('foobar')
+    const result = analyzer.findDefinition({ word: 'foobar' })
     expect(result).toEqual([])
   })
 
   it('returns a list of locations if parameter is found', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
-    const result = analyzer.findDefinition('node_version')
+    const result = analyzer.findDefinition({ word: 'node_version' })
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -27,7 +27,7 @@ export function getGlobPattern(): string {
 export function getHighlightParsingError(): boolean {
   const { HIGHLIGHT_PARSING_ERRORS } = process.env
   return typeof HIGHLIGHT_PARSING_ERRORS !== 'undefined'
-    ? HIGHLIGHT_PARSING_ERRORS === 'true' || HIGHLIGHT_PARSING_ERRORS === '1'
+    ? toBoolean(HIGHLIGHT_PARSING_ERRORS)
     : false
 }
 
@@ -39,3 +39,5 @@ export function getBackgroundAnalysisMaxFiles(): number {
   const parsed = parseInt(BACKGROUND_ANALYSIS_MAX_FILES || '', 10)
   return !isNaN(parsed) ? parsed : DEFAULT_BACKGROUND_ANALYSIS_MAX_FILES
 }
+
+const toBoolean = (s: string): boolean => s === 'true' || s === '1'

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -321,7 +321,7 @@ export default class BashServer {
     if (!word) {
       return null
     }
-    return this.analyzer.findDefinition(word)
+    return this.analyzer.findDefinition({ word })
   }
 
   private onDocumentSymbol(params: LSP.DocumentSymbolParams): LSP.SymbolInformation[] {

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -85,7 +85,9 @@ export async function getShellDocumentationWithoutCache({
           formattedDocumentation = formatManOutput(formattedDocumentation)
         }
 
-        return formattedDocumentation
+        if (formattedDocumentation) {
+          return formattedDocumentation
+        }
       }
     } catch (error) {
       // Ignoring if command fails and store failure in cache


### PR DESCRIPTION
Newer version of OS X fails some unit tests where documentation doesn't show up for `rm` due to changes in the output from `help`. The parsing of this documentation should now be more stable.

I also moved from of the small refactoring from #244.