### PR TITLE
Upgrade tree-sitter-bash GitHub workflow

### DIFF
--- a/.github/workflows/upgrade-tree-sitter.yml
+++ b/.github/workflows/upgrade-tree-sitter.yml
@@ -1,0 +1,38 @@
+on:
+  schedule:
+    - cron: '0 12 * * 2'
+
+jobs:
+  upgrade_tree_sitter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Upgrade tree-sitter wasm
+        run: sh scripts/upgrade-tree-sitter.sh
+
+      - name: Verify changes
+        run: yarn verify:bail
+
+      - name: Verify file changes
+        uses: tj-actions/verify-changed-files@v12
+        id: verify-changed-files
+        with:
+          files: |
+             server/parser.info
+             server/tree-sitter-bash.wasm
+
+      - name: Create pull request
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: server
+          reviewers: skovhus

--- a/.github/workflows/upgrade-tree-sitter.yml
+++ b/.github/workflows/upgrade-tree-sitter.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           add-paths: server
           reviewers: skovhus
+          title: Auto upgrade tree-sitter-bash parser

--- a/scripts/upgrade-tree-sitter.sh
+++ b/scripts/upgrade-tree-sitter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+cd server
+yarn add web-tree-sitter
+yarn add --dev tree-sitter-cli https://github.com/tree-sitter/tree-sitter-bash
+npx tree-sitter build-wasm node_modules/tree-sitter-bash
+
+curl 'https://api.github.com/repos/tree-sitter/tree-sitter-bash/commits/master' | jq .commit.url > parser.info
+echo "tree-sitter-cli $(cat package.json | jq '.devDependencies["tree-sitter-cli"]')" >> parser.info
+
+yarn remove tree-sitter-cli tree-sitter-bash
+

--- a/server/src/parser.ts
+++ b/server/src/parser.ts
@@ -17,17 +17,7 @@ export async function initializeParser(): Promise<Parser> {
    * See https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web#generate-wasm-language-files
    *
    * To compile and use a new tree-sitter-bash version:
-   *    cd server
-   *    yarn add web-tree-sitter
-   *    yarn add --dev tree-sitter-bash tree-sitter-cli
-   *    npx tree-sitter build-wasm node_modules/tree-sitter-bash
-   *
-   * Note down the versions (from the package.json) below and then run
-   *    yarn remove tree-sitter-bash tree-sitter-cli
-   *
-   * The current files was compiled with:
-   * "tree-sitter-bash": "^0.19.0",
-   * "tree-sitter-cli": "^0.20.0"
+   *    sh scripts/upgrade-tree-sitter.sh
    */
   const lang = await Parser.Language.load(`${__dirname}/../tree-sitter-bash.wasm`)
 


### PR DESCRIPTION
Workflow to automatically rebuilt the wasm parser when there is a new tree-sitter version. Here we build directly from the source code as the last tree-sitter-bash npm release is from Mar 4, 2021, and there has been [20 commits ](https://github.com/tree-sitter/tree-sitter-bash/compare/v0.19.0...master) to since the last release...

If/once it is published more often to npm, then we can change this script.

https://github.com/tree-sitter/tree-sitter-bash/issues/134