### PR TITLE
Upgrade LSP dependencies (drops node 12 support)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
 
       - run: |

--- a/.github/workflows/upgrade-tree-sitter.yml
+++ b/.github/workflows/upgrade-tree-sitter.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Use Node.js 12
+      - name: Use Node.js 14
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 14
 
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prettier": "2.8.0",
     "ts-jest": "28.0.8",
     "typescript": "4.9.3",
-    "vscode-languageserver": "6.1.1"
+    "vscode-languageserver": "8.0.2",
+    "vscode-languageserver-textdocument": "1.0.7"
   },
   "dependencies": {},
   "resolutions": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/bash-lsp/bash-language-server"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "dependencies": {
     "fast-glob": "3.2.12",

--- a/server/package.json
+++ b/server/package.json
@@ -18,14 +18,13 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@types/node-fetch": "2.6.2",
     "fast-glob": "3.2.12",
-    "fuzzy-search": "^3.2.1",
-    "node-fetch": "^2.6.7",
-    "turndown": "^7.0.0",
-    "urijs": "^1.19.11",
-    "vscode-languageserver": "^6.1.1",
-    "vscode-languageserver-textdocument": "^1.0.1",
+    "fuzzy-search": "3.2.1",
+    "node-fetch": "2.6.7",
+    "turndown": "7.1.1",
+    "urijs": "1.19.11",
+    "vscode-languageserver": "8.0.2",
+    "vscode-languageserver-textdocument": "1.0.7",
     "web-tree-sitter": "0.20.7"
   },
   "scripts": {
@@ -33,6 +32,7 @@
   },
   "devDependencies": {
     "@types/fuzzy-search": "2.1.2",
+    "@types/node-fetch": "2.6.2",
     "@types/turndown": "5.0.1",
     "@types/urijs": "1.19.19"
   }

--- a/server/src/__tests__/linter.test.ts
+++ b/server/src/__tests__/linter.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'path'
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { FIXTURE_DOCUMENT, FIXTURE_FOLDER } from '../../../testing/fixtures'
 import { getMockConnection } from '../../../testing/mocks'
@@ -8,7 +9,7 @@ import { assertShellcheckResult, Linter } from '../linter'
 const mockConsole = getMockConnection().console
 
 function textToDoc(txt: string) {
-  return LSP.TextDocument.create('foo', 'bar', 0, txt)
+  return TextDocument.create('foo', 'bar', 0, txt)
 }
 
 describe('linter', () => {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -1,6 +1,6 @@
 import * as Process from 'child_process'
 import * as Path from 'path'
-import * as lsp from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 
 import { FIXTURE_FOLDER, FIXTURE_URI } from '../../../testing/fixtures'
 import { getMockConnection } from '../../../testing/mocks'
@@ -8,7 +8,7 @@ import LspServer from '../server'
 import { CompletionItemDataType } from '../types'
 
 async function initializeServer() {
-  const diagnostics: Array<lsp.PublishDiagnosticsParams | undefined> = []
+  const diagnostics: Array<LSP.PublishDiagnosticsParams | undefined> = []
 
   const connection = getMockConnection()
 
@@ -522,7 +522,7 @@ describe('server', () => {
 
     // they are all variables
     expect(Array.from(new Set(result.map((item: any) => item.kind)))).toEqual([
-      lsp.CompletionItemKind.Variable,
+      LSP.CompletionItemKind.Variable,
     ])
   })
 })

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -4,7 +4,8 @@ import fetch from 'node-fetch'
 import * as URI from 'urijs'
 import * as url from 'url'
 import { promisify } from 'util'
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 import * as Parser from 'web-tree-sitter'
 
 import * as config from './config'
@@ -31,7 +32,7 @@ export default class Analyzer {
   private parser: Parser
   private console: LSP.RemoteConsole
 
-  private uriToTextDocument: { [uri: string]: LSP.TextDocument } = {}
+  private uriToTextDocument: { [uri: string]: TextDocument } = {}
 
   private uriToTreeSitterTrees: Trees = {}
 
@@ -110,7 +111,7 @@ export default class Analyzer {
           continue
         }
 
-        this.analyze(uri, LSP.TextDocument.create(uri, 'shell', 1, fileContent))
+        this.analyze(uri, TextDocument.create(uri, 'shell', 1, fileContent))
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : error
         this.console.warn(
@@ -288,7 +289,7 @@ export default class Analyzer {
    * Returns all, if any, syntax errors that occurred while parsing the file.
    *
    */
-  public analyze(uri: string, document: LSP.TextDocument): LSP.Diagnostic[] {
+  public analyze(uri: string, document: TextDocument): LSP.Diagnostic[] {
     const contents = document.getText()
 
     const tree = this.parser.parse(contents)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 
 import BashServer from './server'
 
@@ -9,7 +9,7 @@ const pkg = require('../package')
 export function listen() {
   // Create a connection for the server.
   // The connection uses stdin/stdout for communication.
-  const connection: LSP.IConnection = LSP.createConnection(
+  const connection = LSP.createConnection(
     new LSP.StreamMessageReader(process.stdin),
     new LSP.StreamMessageWriter(process.stdout),
   )

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'child_process'
 import * as LSP from 'vscode-languageserver/node'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 type LinterOptions = {
   executablePath: string | null
@@ -26,7 +27,7 @@ export class Linter {
   }
 
   public async lint(
-    document: LSP.TextDocument,
+    document: TextDocument,
     folders: LSP.WorkspaceFolder[],
   ): Promise<LSP.Diagnostic[]> {
     if (!this.executablePath || !this._canLint) return []
@@ -59,7 +60,7 @@ export class Linter {
 
   private async runShellcheck(
     executablePath: string,
-    document: LSP.TextDocument,
+    document: TextDocument,
     folders: LSP.WorkspaceFolder[],
   ): Promise<ShellcheckResult> {
     const args = [

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process'
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 
 type LinterOptions = {
   executablePath: string | null

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,7 +1,7 @@
 import * as Process from 'child_process'
 import * as Path from 'path'
 import * as TurndownService from 'turndown'
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import Analyzer from './analyser'
@@ -29,7 +29,8 @@ export default class BashServer {
   public static async initialize(
     connection: LSP.Connection,
     { rootPath, capabilities }: LSP.InitializeParams,
-  ): Promise<BashServer> {
+  ): // TODO: use workspaceFolders instead of rootPath
+  Promise<BashServer> {
     const { PATH } = process.env
 
     if (!PATH) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,4 +1,4 @@
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 
 export enum CompletionItemDataType {
   Builtin,

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -1,4 +1,4 @@
-import { Range } from 'vscode-languageserver/lib/main'
+import { Range } from 'vscode-languageserver/node'
 import { SyntaxNode } from 'web-tree-sitter'
 
 export function forEach(node: SyntaxNode, cb: (n: SyntaxNode) => void) {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -114,7 +114,7 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fuzzy-search@^3.2.1:
+fuzzy-search@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/fuzzy-search/-/fuzzy-search-3.2.1.tgz#65d5faad6bc633aee86f1898b7788dfe312ac6c9"
   integrity sha512-vAcPiyomt1ioKAsAL2uxSABHJ4Ju/e4UeDM+g1OlR0vV4YhLGMNsdLNvZTpEDY4JCSt0E4hASCNM5t2ETtsbyg==
@@ -168,7 +168,7 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-node-fetch@^2.6.7:
+node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -209,47 +209,47 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-turndown@^7.0.0:
+turndown@7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.1.1.tgz#96992f2d9b40a1a03d3ea61ad31b5a5c751ef77f"
   integrity sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==
   dependencies:
     domino "^2.1.6"
 
-urijs@^1.19.11:
+urijs@1.19.11:
   version "1.19.11"
   resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
   integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
 
-vscode-languageserver-protocol@^3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
   dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
 
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
-  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
+vscode-languageserver-textdocument@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz#16df468d5c2606103c90554ae05f9f3d335b771b"
+  integrity sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==
 
-vscode-languageserver-types@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
 
-vscode-languageserver@^6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
-  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
+vscode-languageserver@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
   dependencies:
-    vscode-languageserver-protocol "^3.15.3"
+    vscode-languageserver-protocol "3.17.2"
 
 web-tree-sitter@0.20.7:
   version "0.20.7"

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -37,9 +37,9 @@
     form-data "^3.0.0"
 
 "@types/node@*":
-  version "12.7.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.7.tgz#f9bd8c00fa9e1a8129af910fc829f6139c397d6c"
-  integrity sha512-4jUncNe2tj1nmrO/34PsRpZqYVnRV1svbU78cKhuQKkMntKB/AmdLyGgswcZKjFHEHGpiY8pVD8CuVI55nP54w==
+  version "18.11.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
+  integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
 "@types/turndown@5.0.1":
   version "5.0.1"

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -1,11 +1,12 @@
 import * as fs from 'fs'
 import * as path from 'path'
-import * as LSP from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 
 export const FIXTURE_FOLDER = path.join(__dirname, './fixtures/')
 
 function getDocument(uri: string) {
-  return LSP.TextDocument.create(
+  return TextDocument.create(
     'foo',
     'bar',
     0,

--- a/testing/mocks.ts
+++ b/testing/mocks.ts
@@ -1,6 +1,6 @@
-import * as lsp from 'vscode-languageserver'
+import * as LSP from 'vscode-languageserver/node'
 
-export function getMockConnection(): jest.Mocked<lsp.Connection> {
+export function getMockConnection(): jest.Mocked<LSP.Connection> {
   const console: any = {
     error: jest.fn(),
     warn: jest.fn(),
@@ -14,7 +14,9 @@ export function getMockConnection(): jest.Mocked<lsp.Connection> {
     dispose: jest.fn(),
     languages: {} as any,
     listen: jest.fn(),
+    notebooks: {} as any,
     onCodeAction: jest.fn(),
+    onCodeActionResolve: jest.fn(),
     onCodeLens: jest.fn(),
     onCodeLensResolve: jest.fn(),
     onColorPresentation: jest.fn(),
@@ -56,6 +58,7 @@ export function getMockConnection(): jest.Mocked<lsp.Connection> {
     onWillSaveTextDocument: jest.fn(),
     onWillSaveTextDocumentWaitUntil: jest.fn(),
     onWorkspaceSymbol: jest.fn(),
+    onWorkspaceSymbolResolve: jest.fn(),
     sendDiagnostics: jest.fn(),
     sendNotification: jest.fn(),
     sendProgress: jest.fn(),
@@ -66,6 +69,9 @@ export function getMockConnection(): jest.Mocked<lsp.Connection> {
       attachWorkDoneProgress: jest.fn(),
       connection: {} as any,
       createWorkDoneProgress: jest.fn(),
+      fillServerCapabilities: jest.fn(),
+      initialize: jest.fn(),
+      showDocument: jest.fn(),
       showErrorMessage: jest.fn(),
       showInformationMessage: jest.fn(),
       showWarningMessage: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,30 +3053,35 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-vscode-jsonrpc@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
-  integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
+vscode-jsonrpc@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
+  integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
 
-vscode-languageserver-protocol@^3.15.3:
-  version "3.15.3"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.15.3.tgz#3fa9a0702d742cf7883cb6182a6212fcd0a1d8bb"
-  integrity sha512-zrMuwHOAQRhjDSnflWdJG+O2ztMWss8GqUUB8dXLR/FPenwkiBNkMIJJYfSN6sgskvsF0rHAoBowNQfbyZnnvw==
+vscode-languageserver-protocol@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz#beaa46aea06ed061576586c5e11368a9afc1d378"
+  integrity sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==
   dependencies:
-    vscode-jsonrpc "^5.0.1"
-    vscode-languageserver-types "3.15.1"
+    vscode-jsonrpc "8.0.2"
+    vscode-languageserver-types "3.17.2"
 
-vscode-languageserver-types@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
+vscode-languageserver-textdocument@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz#16df468d5c2606103c90554ae05f9f3d335b771b"
+  integrity sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==
 
-vscode-languageserver@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-6.1.1.tgz#d76afc68172c27d4327ee74332b468fbc740d762"
-  integrity sha512-DueEpkUAkD5XTR4MLYNr6bQIp/UFR0/IPApgXU3YfCBCB08u2sm9hRCs6DxYZELkk++STPjpcjksR2H8qI3cDQ==
+vscode-languageserver-types@3.17.2:
+  version "3.17.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
+  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+
+vscode-languageserver@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz#cfe2f0996d9dfd40d3854e786b2821604dfec06d"
+  integrity sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==
   dependencies:
-    vscode-languageserver-protocol "^3.15.3"
+    vscode-languageserver-protocol "3.17.2"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
To enable new features we are here upgrading the language server dependencies. This means that we will be dropping node 12 support, which reached its [official end of life](https://nodejs.org/en/blog/release/v12.22.12/) on April 30th 2022.