### PR TITLE
Remove error codes from message to avoid dupes

### DIFF
--- a/server/src/__tests__/linter.test.ts
+++ b/server/src/__tests__/linter.test.ts
@@ -44,14 +44,14 @@ describe('linter', () => {
 
     const expected: LSP.Diagnostic[] = [
       {
-        message: 'SC2154: foo is referenced but not assigned.',
+        message: 'foo is referenced but not assigned.',
         severity: 2,
         code: 2154,
         source: 'shellcheck',
         range: { start: { line: 1, character: 5 }, end: { line: 1, character: 9 } },
       },
       {
-        message: 'SC2086: Double quote to prevent globbing and word splitting.',
+        message: 'Double quote to prevent globbing and word splitting.',
         severity: 3,
         code: 2086,
         source: 'shellcheck',
@@ -82,8 +82,8 @@ describe('linter', () => {
     })
     // prettier-ignore
     const expected = [
-      { message: 'SC1091: Not following: shellcheck/sourced.sh: openBinaryFile: does not exist (No such file or directory)', severity: 3, code: 1091, source: 'shellcheck', range: { start: { line: 3, character: 7 }, end: { line: 3, character: 19 } }, },
-      { message: 'SC2154: foo is referenced but not assigned.', severity: 2, code: 2154, source: 'shellcheck', range: { start: { line: 5, character: 6 }, end: { line: 5, character: 10 } }, },
+      { message: 'Not following: shellcheck/sourced.sh: openBinaryFile: does not exist (No such file or directory)', severity: 3, code: 1091, source: 'shellcheck', range: { start: { line: 3, character: 7 }, end: { line: 3, character: 19 } }, },
+      { message: 'foo is referenced but not assigned.', severity: 2, code: 2154, source: 'shellcheck', range: { start: { line: 5, character: 6 }, end: { line: 5, character: 10 } }, },
     ]
     const result = await linter.lint(FIXTURE_DOCUMENT.SHELLCHECK_SOURCE, [])
     expect(result).toEqual(expected)

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -1,10 +1,6 @@
 import { spawn } from 'child_process'
 import * as LSP from 'vscode-languageserver'
 
-function formatMessage(comment: ShellcheckComment): string {
-  return (comment.code ? `SC${comment.code}: ` : '') + comment.message
-}
-
 type LinterOptions = {
   executablePath: string | null
   console: LSP.RemoteConsole
@@ -50,7 +46,7 @@ export class Linter {
       }
 
       diags.push({
-        message: formatMessage(comment),
+        message: comment.message,
         severity: mapSeverity(comment.level),
         code: comment.code,
         source: 'shellcheck',


### PR DESCRIPTION
Skip including redundant information in the diagnostic message, since the client can already make
use of the diagnostic code directly.

refs:
  - https://github.com/microsoft/vscode/issues/62159
  - https://github.com/microsoft/vscode/issues/62373
