### PR TITLE
ShellCheck: support configuring arguments and support dialects

### DIFF
--- a/scripts/release-server.sh
+++ b/scripts/release-server.sh
@@ -19,5 +19,5 @@ yarn install
 yarn run verify:bail
 
 cd server
-npm publish
+npm publish --tag beta
 tagRelease $tag

--- a/server/README.md
+++ b/server/README.md
@@ -2,10 +2,11 @@
 
 Bash language server implementation based on [Tree Sitter][tree-sitter] and its [grammar for Bash][tree-sitter-bash]. Integrates with [explainshell][explainshell] and [shellcheck][shellcheck].
 
-For more information see the GitHub repository: [bash-ide/bash-language-server][repo]
+Documentation for environment variables can be found in the [config.ts][https://github.com/bash-lsp/bash-language-server/blob/main/server/src/config.ts] file.
+
+For more information see the GitHub repository: [bash-ide/bash-language-server][https://github.com/bash-lsp/bash-language-server]
 
 [tree-sitter]: https://github.com/tree-sitter/tree-sitter
 [tree-sitter-bash]: https://github.com/tree-sitter/tree-sitter-bash
-[repo]: https://github.com/bash-lsp/bash-language-server
 [explainshell]: https://explainshell.com/
 [shellcheck]: https://www.shellcheck.net/

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "3.3.1",
+  "version": "4.0.0-beta.1",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -24,6 +24,30 @@ describe('getShellcheckPath', () => {
   })
 })
 
+describe('getShellCheckArguments', () => {
+  it('defaults to an empty string', () => {
+    process.env = {}
+    const result = config.getShellCheckArguments()
+    expect(result).toEqual([])
+  })
+
+  it('parses environment variable', () => {
+    process.env = {
+      SHELLCHECK_ARGUMENTS: '-e SC2001',
+    }
+    const result = config.getShellCheckArguments()
+    expect(result).toEqual(['-e', 'SC2001'])
+  })
+
+  it('parses environment variable with excessive white space', () => {
+    process.env = {
+      SHELLCHECK_ARGUMENTS: ' -e SC2001  -e SC2002 ',
+    }
+    const result = config.getShellCheckArguments()
+    expect(result).toEqual(['-e', 'SC2001', '-e', 'SC2002'])
+  })
+})
+
 describe('getExplainshellEndpoint', () => {
   it('default to null', () => {
     process.env = {}

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -11,7 +11,7 @@ import * as Parser from 'web-tree-sitter'
 import * as config from './config'
 import { flattenArray, flattenObjectValues } from './util/flatten'
 import { getFilePaths } from './util/fs'
-import { getShebang, isBashShebang } from './util/shebang'
+import { analyzeShebang } from './util/shebang'
 import * as TreeSitterUtil from './util/tree-sitter'
 
 const readFileAsync = promisify(fs.readFile)
@@ -103,8 +103,8 @@ export default class Analyzer {
 
       try {
         const fileContent = await readFileAsync(filePath, 'utf8')
-        const shebang = getShebang(fileContent)
-        if (shebang && !isBashShebang(shebang)) {
+        const { shebang, shellDialect } = analyzeShebang(fileContent)
+        if (shebang && !shellDialect) {
           this.console.log(
             `BackgroundAnalysis: Skipping file ${uri} with shebang "${shebang}"`,
           )

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -7,6 +7,20 @@ export function getShellcheckPath(): string | null {
   return typeof SHELLCHECK_PATH === 'string' ? SHELLCHECK_PATH || null : 'shellcheck'
 }
 
+/**
+ * Get additional shellcheck arguments from the environment.
+ * NOTE: That we already add the following arguments: --shell, --format, --external-sources
+ */
+export function getShellCheckArguments(): string[] {
+  const { SHELLCHECK_ARGUMENTS } = process.env
+  if (typeof SHELLCHECK_ARGUMENTS === 'string') {
+    return SHELLCHECK_ARGUMENTS.split(' ')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  }
+  return []
+}
+
 export function getExplainshellEndpoint(): string | null {
   const { EXPLAINSHELL_ENDPOINT } = process.env
   return typeof EXPLAINSHELL_ENDPOINT === 'string' && EXPLAINSHELL_ENDPOINT.trim() !== ''

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -101,6 +101,8 @@ export class Linter {
       }
     }
 
+    this.console.log(`ShellCheck: running "${executablePath} ${args.join(' ')}"`)
+
     let out = ''
     let err = ''
     const proc = new Promise((resolve, reject) => {

--- a/server/src/linter.ts
+++ b/server/src/linter.ts
@@ -96,7 +96,9 @@ export class Linter {
       ...additionalArgs,
     ]
     for (const folder of folders) {
-      args.push(`--source-path=${folder.name}`)
+      if (folder.name.trim()) {
+        args.push(`--source-path=${folder.name}`)
+      }
     }
 
     let out = ''

--- a/server/src/util/__tests__/shebang.test.ts
+++ b/server/src/util/__tests__/shebang.test.ts
@@ -1,28 +1,34 @@
-import { hasBashShebang } from '../shebang'
+import { analyzeShebang } from '../shebang'
 
-describe('hasBashShebang', () => {
-  it('returns false for empty file', () => {
-    expect(hasBashShebang('')).toBe(false)
+describe('analyzeShebang', () => {
+  it('returns null for an empty file', () => {
+    expect(analyzeShebang('')).toEqual({ shellDialect: null, shebang: null })
   })
 
-  it('returns false for python files', () => {
-    expect(hasBashShebang(`#!/usr/bin/env python2.7\n# set -x`)).toBe(false)
+  it('returns no shell dialect for python files', () => {
+    expect(analyzeShebang(`#!/usr/bin/env python2.7\n# set -x`)).toEqual({
+      shellDialect: null,
+      shebang: '/usr/bin/env python2.7',
+    })
   })
 
-  it('returns false for "#!/usr/bin/pwsh"', () => {
-    expect(hasBashShebang('#!/usr/bin/pwsh')).toBe(false)
+  it('returns no shell dialect for unsupported shell "#!/usr/bin/zsh"', () => {
+    expect(analyzeShebang('#!/usr/bin/zsh')).toEqual({
+      shellDialect: null,
+      shebang: '/usr/bin/zsh',
+    })
   })
 
   test.each([
-    ['#!/bin/sh -'],
-    ['#!/usr/bin/env bash'],
-    ['#!/bin/sh'],
-    ['#!/bin/bash'],
-    ['#!/bin/bash -u'],
-    ['#! /bin/bash'],
-    ['#!/usr/bin/bash'],
-  ])('returns true for %p', (command) => {
-    expect(hasBashShebang(command)).toBe(true)
-    expect(hasBashShebang(`${command} `)).toBe(true)
+    ['#!/bin/sh -', 'sh'],
+    ['#!/usr/bin/env bash', 'bash'],
+    ['#!/bin/sh', 'sh'],
+    ['#!/bin/bash', 'bash'],
+    ['#!/bin/bash -u', 'bash'],
+    ['#! /bin/bash', 'bash'],
+    ['#!/usr/bin/bash', 'bash'],
+  ])('returns a bash dialect for %p', (command, expectedDialect) => {
+    expect(analyzeShebang(command).shellDialect).toBe(expectedDialect)
+    expect(analyzeShebang(`${command} `).shellDialect).toBe(expectedDialect)
   })
 })

--- a/server/src/util/shebang.ts
+++ b/server/src/util/shebang.ts
@@ -1,5 +1,9 @@
 const SHEBANG_REGEXP = /^#!(.*)/
 
+// TODO: at some point we could let this return all known shells (like dash, ksh, etc)
+// and make the call side decide what to support.
+type SupportedBashDialect = 'bash' | 'sh'
+
 export function getShebang(fileContent: string): string | null {
   const match = SHEBANG_REGEXP.exec(fileContent)
   if (!match || !match[1]) {
@@ -9,20 +13,29 @@ export function getShebang(fileContent: string): string | null {
   return match[1].trim()
 }
 
-/**
- * Check if the given shebang is a bash shebang.
- */
-export function isBashShebang(shebang: string): boolean {
-  return (
+export function getShellDialect(shebang: string): SupportedBashDialect | null {
+  if (shebang.startsWith('/bin/sh') || shebang.startsWith('/usr/bin/env sh')) {
+    return 'sh'
+  }
+
+  if (
     shebang.startsWith('/bin/bash') ||
-    shebang.startsWith('/bin/sh') ||
     shebang.startsWith('/usr/bin/bash') ||
-    shebang.startsWith('/usr/bin/env bash') ||
-    shebang.startsWith('/usr/bin/env sh')
-  )
+    shebang.startsWith('/usr/bin/env bash')
+  ) {
+    return 'bash'
+  }
+
+  return null
 }
 
-export function hasBashShebang(fileContent: string): boolean {
+export function analyzeShebang(fileContent: string): {
+  shellDialect: SupportedBashDialect | null
+  shebang: string | null
+} {
   const shebang = getShebang(fileContent)
-  return shebang ? isBashShebang(shebang) : false
+  return {
+    shebang,
+    shellDialect: shebang ? getShellDialect(shebang) : null,
+  }
 }

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -50,6 +50,11 @@
           "type": "string",
           "default": "shellcheck",
           "description": "Controls the executable used for ShellCheck linting information. An empty string will disable linting."
+        },
+        "bashIde.shellcheckArguments": {
+          "type": "string",
+          "default": "",
+          "description": "Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, --external-sources."
         }
       }
     }

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -9,24 +9,15 @@ import {
 } from 'vscode-languageclient'
 
 export async function activate(context: ExtensionContext) {
-  const explainshellEndpoint = workspace
-    .getConfiguration('bashIde')
-    .get('explainshellEndpoint', '')
-
-  const globPattern = workspace.getConfiguration('bashIde').get('globPattern', '')
-
-  const highlightParsingErrors = workspace
-    .getConfiguration('bashIde')
-    .get('highlightParsingErrors', false)
-
-  const shellcheckPath = workspace.getConfiguration('bashIde').get('shellcheckPath', '')
+  const config = workspace.getConfiguration('bashIde')
 
   const env: any = {
     ...process.env,
-    SHELLCHECK_PATH: shellcheckPath,
-    EXPLAINSHELL_ENDPOINT: explainshellEndpoint,
-    GLOB_PATTERN: globPattern,
-    HIGHLIGHT_PARSING_ERRORS: highlightParsingErrors,
+    SHELLCHECK_PATH: config.get('shellcheckPath', ''),
+    SHELLCHECK_ARGUMENTS: config.get('shellcheckArguments', ''),
+    EXPLAINSHELL_ENDPOINT: config.get('explainshellEndpoint', ''),
+    GLOB_PATTERN: config.get('globPattern', ''),
+    HIGHLIGHT_PARSING_ERRORS: config.get('highlightParsingErrors', false),
   }
 
   const serverExecutable = {


### PR DESCRIPTION
We now also start publishing a beta release for the upcoming server version 4 (breaking change as the support for node version 12 has been dropped). 

https://github.com/bash-lsp/bash-language-server/issues/578 https://github.com/bash-lsp/bash-language-server/issues/576 https://github.com/bash-lsp/bash-language-server/issues/586