### PR TITLE
Default to workspace configuration instead of environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "vscode-languageserver": "8.0.2",
     "vscode-languageserver-textdocument": "1.0.7"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "3.19.1"
+  },
   "resolutions": {
     "sane": "^5.0.0"
   },

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -1,6 +1,7 @@
 import FIXTURES, { FIXTURE_FOLDER } from '../../../testing/fixtures'
 import { getMockConnection } from '../../../testing/mocks'
 import Analyzer from '../analyser'
+import { getDefaultConfiguration } from '../config'
 import { initializeParser } from '../parser'
 import * as fsUtil from '../util/fs'
 
@@ -11,6 +12,8 @@ const mockConsole = getMockConnection().console
 
 // if you add a .sh file to testing/fixtures, update this value
 const FIXTURE_FILES_MATCHING_GLOB = 13
+
+const defaultConfig = getDefaultConfiguration()
 
 beforeAll(async () => {
   const parser = await initializeParser()
@@ -276,6 +279,8 @@ describe('initiateBackgroundAnalysis', () => {
 
     const newAnalyzer = new Analyzer({ console: connection.console, parser })
     const { filesParsed } = await newAnalyzer.initiateBackgroundAnalysis({
+      backgroundAnalysisMaxFiles: defaultConfig.backgroundAnalysisMaxFiles,
+      globPattern: defaultConfig.globPattern,
       rootPath: FIXTURE_FOLDER,
     })
 
@@ -302,6 +307,8 @@ describe('initiateBackgroundAnalysis', () => {
 
     const newAnalyzer = new Analyzer({ console: connection.console, parser })
     const { filesParsed } = await newAnalyzer.initiateBackgroundAnalysis({
+      backgroundAnalysisMaxFiles: defaultConfig.backgroundAnalysisMaxFiles,
+      globPattern: defaultConfig.globPattern,
       rootPath: FIXTURE_FOLDER,
     })
 

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -1,33 +1,71 @@
-import * as config from '../config'
+import { ConfigSchema, getConfigFromEnvironmentVariables } from '../config'
 
+describe('ConfigSchema', () => {
+  it('parses an object', () => {
+    expect(ConfigSchema.parse({})).toMatchInlineSnapshot(`
+      Object {
+        "backgroundAnalysisMaxFiles": 500,
+        "explainshellEndpoint": "",
+        "globPattern": "**/*@(.sh|.inc|.bash|.command)",
+        "highlightParsingErrors": false,
+        "shellcheckArguments": Array [],
+        "shellcheckPath": "shellcheck",
+      }
+    `)
+    expect(
+      ConfigSchema.parse({
+        backgroundAnalysisMaxFiles: 1,
+        explainshellEndpoint: 'localhost:8080',
+        globPattern: '**/*@(.sh)',
+        highlightParsingErrors: true,
+        shellcheckArguments: ' -e SC2001  -e SC2002 ',
+        shellcheckPath: '',
+      }),
+    ).toMatchInlineSnapshot(`
+      Object {
+        "backgroundAnalysisMaxFiles": 1,
+        "explainshellEndpoint": "localhost:8080",
+        "globPattern": "**/*@(.sh)",
+        "highlightParsingErrors": true,
+        "shellcheckArguments": Array [
+          "-e",
+          "SC2001",
+          "-e",
+          "SC2002",
+        ],
+        "shellcheckPath": "",
+      }
+    `)
+  })
+})
 describe('getShellcheckPath', () => {
-  it('defaults to shellcheck without path', () => {
+  it('defaults to "shellcheck"', () => {
     process.env = {}
-    const result = config.getShellcheckPath()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckPath
     expect(result).toEqual('shellcheck')
   })
 
-  it('default to null in case of an empty string', () => {
+  it('preserves an empty string', () => {
     process.env = {
       SHELLCHECK_PATH: '',
     }
-    const result = config.getShellcheckPath()
-    expect(result).toBeNull()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckPath
+    expect(result).toEqual('')
   })
 
   it('parses environment variable', () => {
     process.env = {
       SHELLCHECK_PATH: '/path/to/shellcheck',
     }
-    const result = config.getShellcheckPath()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckPath
     expect(result).toEqual('/path/to/shellcheck')
   })
 })
 
 describe('getShellCheckArguments', () => {
-  it('defaults to an empty string', () => {
+  it('defaults to an empty array', () => {
     process.env = {}
-    const result = config.getShellCheckArguments()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckArguments
     expect(result).toEqual([])
   })
 
@@ -35,7 +73,7 @@ describe('getShellCheckArguments', () => {
     process.env = {
       SHELLCHECK_ARGUMENTS: '-e SC2001',
     }
-    const result = config.getShellCheckArguments()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckArguments
     expect(result).toEqual(['-e', 'SC2001'])
   })
 
@@ -43,55 +81,41 @@ describe('getShellCheckArguments', () => {
     process.env = {
       SHELLCHECK_ARGUMENTS: ' -e SC2001  -e SC2002 ',
     }
-    const result = config.getShellCheckArguments()
+    const result = getConfigFromEnvironmentVariables().config.shellcheckArguments
     expect(result).toEqual(['-e', 'SC2001', '-e', 'SC2002'])
   })
 })
 
 describe('getExplainshellEndpoint', () => {
-  it('default to null', () => {
+  it('default to an empty string', () => {
     process.env = {}
-    const result = config.getExplainshellEndpoint()
-    expect(result).toBeNull()
+    const result = getConfigFromEnvironmentVariables().config.explainshellEndpoint
+    expect(result).toEqual('')
   })
 
-  it('default to null in case of an empty string', () => {
+  it('preserves the empty string', () => {
     process.env = {
       EXPLAINSHELL_ENDPOINT: '',
     }
-    const result = config.getExplainshellEndpoint()
-    expect(result).toBeNull()
+    const result = getConfigFromEnvironmentVariables().config.explainshellEndpoint
+    expect(result).toEqual('')
   })
 
   it('parses environment variable', () => {
     process.env = {
       EXPLAINSHELL_ENDPOINT: 'localhost:8080',
     }
-    const result = config.getExplainshellEndpoint()
+    const result = getConfigFromEnvironmentVariables().config.explainshellEndpoint
     expect(result).toEqual('localhost:8080')
   })
 })
 
 describe('getGlobPattern', () => {
-  it('default to a basic glob', () => {
-    process.env = {}
-    const result = config.getGlobPattern()
-    expect(result).toEqual(config.DEFAULT_GLOB_PATTERN)
-  })
-
-  it('default to a basic glob in case of an empty string', () => {
-    process.env = {
-      GLOB_PATTERN: '',
-    }
-    const result = config.getGlobPattern()
-    expect(result).toEqual(config.DEFAULT_GLOB_PATTERN)
-  })
-
   it('parses environment variable', () => {
     process.env = {
       GLOB_PATTERN: '*.*',
     }
-    const result = config.getGlobPattern()
+    const result = getConfigFromEnvironmentVariables().config.globPattern
     expect(result).toEqual('*.*')
   })
 })
@@ -99,7 +123,7 @@ describe('getGlobPattern', () => {
 describe('highlightParsingError', () => {
   it('default to false', () => {
     process.env = {}
-    const result = config.getHighlightParsingError()
+    const result = getConfigFromEnvironmentVariables().config.highlightParsingErrors
     expect(result).toEqual(false)
   })
 
@@ -107,25 +131,25 @@ describe('highlightParsingError', () => {
     process.env = {
       HIGHLIGHT_PARSING_ERRORS: 'true',
     }
-    let result = config.getHighlightParsingError()
+    let result = getConfigFromEnvironmentVariables().config.highlightParsingErrors
     expect(result).toEqual(true)
 
     process.env = {
       HIGHLIGHT_PARSING_ERRORS: '1',
     }
-    result = config.getHighlightParsingError()
+    result = getConfigFromEnvironmentVariables().config.highlightParsingErrors
     expect(result).toEqual(true)
 
     process.env = {
       HIGHLIGHT_PARSING_ERRORS: '0',
     }
-    result = config.getHighlightParsingError()
+    result = getConfigFromEnvironmentVariables().config.highlightParsingErrors
     expect(result).toEqual(false)
 
     process.env = {
       HIGHLIGHT_PARSING_ERRORS: 'false',
     }
-    result = config.getHighlightParsingError()
+    result = getConfigFromEnvironmentVariables().config.highlightParsingErrors
     expect(result).toEqual(false)
   })
 })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -21,11 +21,10 @@ async function initializeServer() {
     workspaceFolders: null,
   })
 
-  const { backgroundAnalysisCompleted } = server
-
-  if (backgroundAnalysisCompleted) {
-    await backgroundAnalysisCompleted
-  }
+  server.register(connection)
+  const onInitialized = connection.onInitialized.mock.calls[0][0]
+  const { backgroundAnalysisCompleted } = (await onInitialized({})) as any
+  await backgroundAnalysisCompleted
 
   return {
     connection,
@@ -42,9 +41,7 @@ describe('server', () => {
   })
 
   it('register LSP connection', async () => {
-    const { connection, server } = await initializeServer()
-
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     expect(connection.onHover).toHaveBeenCalledTimes(1)
     expect(connection.onDefinition).toHaveBeenCalledTimes(1)
@@ -58,8 +55,7 @@ describe('server', () => {
   })
 
   it('responds to onHover', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onHover = connection.onHover.mock.calls[0][0]
 
@@ -87,8 +83,7 @@ describe('server', () => {
   })
 
   it('responds to onHover with function documentation extracted from comments', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onHover = connection.onHover.mock.calls[0][0]
 
@@ -114,8 +109,7 @@ describe('server', () => {
   })
 
   it('responds to onDocumentHighlight', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onDocumentHighlight = connection.onDocumentHighlight.mock.calls[0][0]
 
@@ -195,8 +189,7 @@ describe('server', () => {
   })
 
   it('responds to onWorkspaceSymbol', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onWorkspaceSymbol = connection.onWorkspaceSymbol.mock.calls[0][0]
 
@@ -241,8 +234,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with filtered list when word is found', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -289,8 +281,7 @@ describe('server', () => {
       return
     }
 
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -324,8 +315,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with entire list when no word is found', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -349,8 +339,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with empty list when word is a comment', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -373,8 +362,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with empty list when word is {', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -397,8 +385,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion when word is found in another file', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -466,8 +453,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with local symbol when word is found in multiple files', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -502,8 +488,7 @@ describe('server', () => {
   })
 
   it('responds to onCompletion with all variables when starting to expand parameters', async () => {
-    const { connection, server } = await initializeServer()
-    server.register(connection)
+    const { connection } = await initializeServer()
 
     const onCompletion = connection.onCompletion.mock.calls[0][0]
 
@@ -532,7 +517,6 @@ describe('server', () => {
     const { connection, server } = await initializeServer()
     const document = FIXTURE_DOCUMENT.COMMENT_DOC
 
-    server.register(connection)
     await server.onDocumentContentChange(document)
 
     expect(connection.sendDiagnostics).toHaveBeenCalledTimes(1)

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -8,7 +8,6 @@ import * as LSP from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import * as Parser from 'web-tree-sitter'
 
-import * as config from './config'
 import { flattenArray, flattenObjectValues } from './util/flatten'
 import { getFilePaths } from './util/fs'
 import { analyzeShebang } from './util/shebang'
@@ -60,12 +59,14 @@ export default class Analyzer {
    * enable features across files.
    */
   public async initiateBackgroundAnalysis({
+    backgroundAnalysisMaxFiles,
+    globPattern,
     rootPath,
   }: {
+    backgroundAnalysisMaxFiles: number
+    globPattern: string
     rootPath: string
   }): Promise<{ filesParsed: number }> {
-    const globPattern = config.getGlobPattern()
-    const backgroundAnalysisMaxFiles = config.getBackgroundAnalysisMaxFiles()
     this.console.log(
       `BackgroundAnalysis: resolving glob "${globPattern}" inside "${rootPath}"...`,
     )

--- a/server/src/shellcheck/__tests__/index.test.ts
+++ b/server/src/shellcheck/__tests__/index.test.ts
@@ -12,11 +12,7 @@ function textToDoc(txt: string) {
 }
 
 describe('linter', () => {
-  it('should set canLint to false if executable empty', () => {
-    expect(new Linter({ console: mockConsole, executablePath: null }).canLint).toBe(false)
-  })
-
-  it('should set canLint to true if executable not empty', () => {
+  it('default to canLint to true', () => {
     expect(new Linter({ console: mockConsole, executablePath: 'foo' }).canLint).toBe(true)
   })
 

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -52,7 +52,7 @@ export async function activate(context: ExtensionContext) {
       },
     ],
     synchronize: {
-      configurationSection: 'Bash IDE',
+      configurationSection: 'bashIde',
       // Notify the server about file changes to '.clientrc files contain in the workspace
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -12,15 +12,8 @@ import {
 let client: LanguageClient
 
 export async function activate(context: ExtensionContext) {
-  const config = workspace.getConfiguration('bashIde')
-
   const env: any = {
     ...process.env,
-    SHELLCHECK_PATH: config.get('shellcheckPath', ''),
-    SHELLCHECK_ARGUMENTS: config.get('shellcheckArguments', ''),
-    EXPLAINSHELL_ENDPOINT: config.get('explainshellEndpoint', ''),
-    GLOB_PATTERN: config.get('globPattern', ''),
-    HIGHLIGHT_PARSING_ERRORS: config.get('highlightParsingErrors', false),
   }
 
   const serverExecutable = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,3 +3168,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==


### PR DESCRIPTION
This enables updating configuration for the bash-language-server without reloading the server. We still support environment variables, but clients using bash-language-server should migrate to the new workspace configuration.