### PR TITLE
Shell documentation: noprofile norc flags

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bash Language Server
 
+## 4.1.1
+
+- Background analysis: handle workspace root being a URL https://github.com/bash-lsp/bash-language-server/pull/625
+- Shell documentation: add `--noprofile --norc` to avoid config files breaking formatting https://github.com/bash-lsp/bash-language-server/pull/626
+
 ## 4.1.0
 
 - Symbols across files are now only included based on sourced files (using non dynamic statements like `source file.sh` or `. ~/file.inc`) instead of including symbols from all files in the workspace. We now also support jump-to-definition on the file path used in a source command. The new behavior can be disabled by turning on the `includeAllWorkspaceSymbols` configuration option. https://github.com/bash-lsp/bash-language-server/pull/244

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -14,7 +14,7 @@ export function execShellScript(
   if (cmd === 'cmd.exe') {
     args.push('/c', body)
   } else {
-    args.push('--noprofile', '-c', body)
+    args.push('--noprofile', '--norc', '-c', body)
   }
 
   const process = ChildProcess.spawn(cmd, args)

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -14,7 +14,7 @@ export function execShellScript(
   if (cmd === 'cmd.exe') {
     args.push('/c', body)
   } else {
-    args.push('-c', body)
+    args.push('--noprofile', '-c', body)
   }
 
   const process = ChildProcess.spawn(cmd, args)


### PR DESCRIPTION
https://github.com/bash-lsp/bash-language-server/issues/619

This ensures that config files should break the documentation output.