### PR TITLE
Pass in correct source path to ShellCheck

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,7 +1,8 @@
-import { spawnSync } from 'child_process'
-import * as path from 'path'
+import { spawnSync } from 'node:child_process'
+import * as path from 'node:path'
+import { isDeepStrictEqual } from 'node:util'
+
 import * as TurndownService from 'turndown'
-import { isDeepStrictEqual } from 'util'
 import * as LSP from 'vscode-languageserver/node'
 import { CodeAction } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -260,12 +261,10 @@ export default class BashServer {
     // Run ShellCheck diagnostics:
     if (this.linter) {
       try {
-        const folders = this.clientCapabilities.workspace?.workspaceFolders
-          ? await this.connection.workspace.getWorkspaceFolders()
-          : []
+        const sourceFolders = this.workspaceFolder ? [this.workspaceFolder] : []
         const { diagnostics: lintDiagnostics, codeActions } = await this.linter.lint(
           document,
-          folders || [],
+          sourceFolders,
           this.config.shellcheckArguments,
         )
         diagnostics = diagnostics.concat(lintDiagnostics)

--- a/server/src/shellcheck/__tests__/index.test.ts
+++ b/server/src/shellcheck/__tests__/index.test.ts
@@ -8,7 +8,7 @@ import { Linter } from '../index'
 const mockConsole = getMockConnection().console
 
 function textToDoc(txt: string) {
-  return TextDocument.create('foo', 'bar', 0, txt)
+  return TextDocument.create(`file://${FIXTURE_FOLDER}/foo.sh`, 'bar', 0, txt)
 }
 
 describe('linter', () => {
@@ -220,14 +220,14 @@ describe('linter', () => {
     `)
   })
 
-  it('should follow sources with incorrect cwd if correct path is passed as a workspace path', async () => {
+  it('should follow sources with incorrect cwd and if correct path is passed as a source path', async () => {
     const linter = new Linter({
       console: mockConsole,
       cwd: path.resolve(path.join(FIXTURE_FOLDER, '../')),
       executablePath: 'shellcheck',
     })
     const result = await linter.lint(FIXTURE_DOCUMENT.SHELLCHECK_SOURCE, [
-      { uri: `file://${path.resolve(FIXTURE_FOLDER)}`, name: 'fixtures' },
+      path.resolve(FIXTURE_FOLDER),
     ])
     expect(result).toEqual({
       codeActions: [],


### PR DESCRIPTION
With this change we should hopefully get ShellCheck following sourced files in multiple cases:
- if the scripts are executed from the root folder (e.g. a file `scripts/foo.sh` includes using `source "scripts/foo.inc"`)
- if the scripts are executed from a sub folder (e.g. a file `scripts/sub/foo.sh` includes using `source "../foo.inc"`)

Note that we used to pass in multiple workspace folders, although the language server doesn't really support them yet.
