### PR TITLE
Scope aware symbol resolution

### DIFF
--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -114,11 +114,99 @@ Array [
     },
     "name": "add_a_user",
   },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 9,
+          "line": 5,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 5,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "USER",
+  },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 13,
+          "line": 6,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 6,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "PASSWORD",
+  },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 13,
+          "line": 9,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 9,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "COMMENTS",
+  },
 ]
 `;
 
 exports[`getDeclarationsForUri returns a list of SymbolInformation if uri is found 1`] = `
 Array [
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 8,
+          "line": 21,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 21,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 8,
+          "line": 30,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 30,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
   Object {
     "kind": 13,
     "location": Object {
@@ -158,6 +246,23 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
+          "character": 31,
+          "line": 48,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 48,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "npm_config_loglevel",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
           "character": 22,
           "line": 53,
         },
@@ -176,16 +281,50 @@ Array [
       "range": Object {
         "end": Object {
           "character": 6,
-          "line": 265,
+          "line": 54,
         },
         "start": Object {
           "character": 0,
-          "line": 265,
+          "line": 54,
         },
       },
       "uri": "dummy-uri.sh",
     },
     "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 15,
+          "line": 69,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 69,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "TMP",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 12,
+          "line": 71,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 71,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "TMP",
   },
   Object {
     "kind": 13,
@@ -226,6 +365,23 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
+          "character": 5,
+          "line": 83,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 83,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
           "character": 12,
           "line": 84,
         },
@@ -237,6 +393,74 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "tar",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 25,
+          "line": 86,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 86,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "tar",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 22,
+          "line": 89,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 89,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "tar",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 8,
+          "line": 90,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 90,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 8,
+          "line": 97,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 97,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
   },
   Object {
     "kind": 13,
@@ -260,6 +484,108 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
+          "character": 25,
+          "line": 119,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 119,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 26,
+          "line": 123,
+        },
+        "start": Object {
+          "character": 4,
+          "line": 123,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 17,
+          "line": 127,
+        },
+        "start": Object {
+          "character": 6,
+          "line": 127,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 14,
+          "line": 131,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 131,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 13,
+          "line": 138,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 138,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 12,
+          "line": 145,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 145,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "clean",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
           "character": 37,
           "line": 148,
         },
@@ -271,6 +597,23 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "node_version",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 6,
+          "line": 149,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 149,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
   },
   Object {
     "kind": 13,
@@ -294,6 +637,23 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
+          "character": 16,
+          "line": 170,
+        },
+        "start": Object {
+          "character": 6,
+          "line": 170,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "t",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
           "character": 25,
           "line": 179,
         },
@@ -305,6 +665,312 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "url",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 6,
+          "line": 181,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 181,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 9,
+          "line": 183,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 183,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 24,
+          "line": 187,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 185,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "url",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 8,
+          "line": 188,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 188,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 11,
+          "line": 190,
+        },
+        "start": Object {
+          "character": 4,
+          "line": 190,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 65,
+          "line": 205,
+        },
+        "start": Object {
+          "character": 6,
+          "line": 205,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ver",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 15,
+          "line": 206,
+        },
+        "start": Object {
+          "character": 6,
+          "line": 206,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "isnpm10",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 21,
+          "line": 211,
+        },
+        "start": Object {
+          "character": 12,
+          "line": 211,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "isnpm10",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 21,
+          "line": 215,
+        },
+        "start": Object {
+          "character": 12,
+          "line": 215,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "isnpm10",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 11,
+          "line": 220,
+        },
+        "start": Object {
+          "character": 6,
+          "line": 220,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 18,
+          "line": 225,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 225,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "clean",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 15,
+          "line": 230,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 230,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 22,
+          "line": 232,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 232,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "NODE",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 16,
+          "line": 233,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 233,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 22,
+          "line": 235,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 235,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "NODE",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 16,
+          "line": 236,
+        },
+        "start": Object {
+          "character": 10,
+          "line": 236,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 21,
+          "line": 255,
+        },
+        "start": Object {
+          "character": 8,
+          "line": 255,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "make",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 6,
+          "line": 265,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 265,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "ret",
   },
 ]
 `;

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -56,19 +56,6 @@ Array [
   Object {
     "range": Object {
       "end": Object {
-        "character": 12,
-        "line": 148,
-      },
-      "start": Object {
-        "character": 0,
-        "line": 148,
-      },
-    },
-    "uri": "dummy-uri.sh",
-  },
-  Object {
-    "range": Object {
-      "end": Object {
         "character": 45,
         "line": 152,
       },

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -95,7 +95,7 @@ Array [
 ]
 `;
 
-exports[`findSymbolsForFile issue 101 1`] = `
+exports[`getDeclarationsForUri issue 101 1`] = `
 Array [
   Object {
     "kind": 12,
@@ -117,7 +117,7 @@ Array [
 ]
 `;
 
-exports[`findSymbolsForFile returns a list of SymbolInformation if uri is found 1`] = `
+exports[`getDeclarationsForUri returns a list of SymbolInformation if uri is found 1`] = `
 Array [
   Object {
     "kind": 13,

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -22,7 +22,7 @@ Array [
 exports[`analyze returns a list of errors for a file with parsing errors 1`] = `
 Array [
   Object {
-    "message": "Failed to parse expression",
+    "message": "Failed to parse",
     "range": Object {
       "end": Object {
         "character": 1,
@@ -127,60 +127,6 @@ Array [
     },
     "name": "add_a_user",
   },
-  Object {
-    "containerName": "add_a_user",
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 9,
-          "line": 5,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 5,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "USER",
-  },
-  Object {
-    "containerName": "add_a_user",
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 13,
-          "line": 6,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 6,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "PASSWORD",
-  },
-  Object {
-    "containerName": "add_a_user",
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 13,
-          "line": 9,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 9,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "COMMENTS",
-  },
 ]
 `;
 
@@ -191,34 +137,51 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 8,
-          "line": 21,
+          "character": 68,
+          "line": 38,
         },
         "start": Object {
-          "character": 2,
-          "line": 21,
+          "character": 0,
+          "line": 38,
         },
       },
       "uri": "dummy-uri.sh",
     },
-    "name": "ret",
+    "name": "configures",
   },
   Object {
     "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 8,
-          "line": 30,
+          "character": 27,
+          "line": 40,
         },
         "start": Object {
-          "character": 2,
-          "line": 30,
+          "character": 0,
+          "line": 40,
         },
       },
       "uri": "dummy-uri.sh",
     },
-    "name": "ret",
+    "name": "npm_config_loglevel",
+  },
+  Object {
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 22,
+          "line": 53,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 53,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "node",
   },
   Object {
     "kind": 13,
@@ -259,40 +222,6 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 8,
-          "line": 90,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 90,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 8,
-          "line": 97,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 97,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
           "character": 6,
           "line": 149,
         },
@@ -327,125 +256,6 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 9,
-          "line": 183,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 183,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 8,
-          "line": 188,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 188,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 11,
-          "line": 190,
-        },
-        "start": Object {
-          "character": 4,
-          "line": 190,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 11,
-          "line": 220,
-        },
-        "start": Object {
-          "character": 6,
-          "line": 220,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 15,
-          "line": 230,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 230,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 16,
-          "line": 233,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 233,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 16,
-          "line": 236,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 236,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
           "character": 6,
           "line": 265,
         },
@@ -463,97 +273,12 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 68,
-          "line": 38,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 38,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "configures",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 27,
-          "line": 40,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 40,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "npm_config_loglevel",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 31,
-          "line": 48,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 48,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "npm_config_loglevel",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 22,
-          "line": 53,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 53,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "node",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
           "character": 15,
           "line": 69,
         },
         "start": Object {
           "character": 0,
           "line": 69,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "TMP",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 12,
-          "line": 71,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 71,
         },
       },
       "uri": "dummy-uri.sh",
@@ -616,40 +341,6 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 25,
-          "line": 86,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 86,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "tar",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 22,
-          "line": 89,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 89,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "tar",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
           "character": 11,
           "line": 116,
         },
@@ -661,142 +352,6 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "MAKE",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 25,
-          "line": 119,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 119,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 26,
-          "line": 123,
-        },
-        "start": Object {
-          "character": 4,
-          "line": 123,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 17,
-          "line": 127,
-        },
-        "start": Object {
-          "character": 6,
-          "line": 127,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 14,
-          "line": 131,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 131,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 13,
-          "line": 138,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 138,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 21,
-          "line": 255,
-        },
-        "start": Object {
-          "character": 8,
-          "line": 255,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "make",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 12,
-          "line": 145,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 145,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "clean",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 18,
-          "line": 225,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 225,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "clean",
   },
   Object {
     "kind": 13,
@@ -837,23 +392,6 @@ Array [
     "location": Object {
       "range": Object {
         "end": Object {
-          "character": 16,
-          "line": 170,
-        },
-        "start": Object {
-          "character": 6,
-          "line": 170,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "t",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
           "character": 25,
           "line": 179,
         },
@@ -865,125 +403,6 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "url",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 24,
-          "line": 187,
-        },
-        "start": Object {
-          "character": 2,
-          "line": 185,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "url",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 65,
-          "line": 205,
-        },
-        "start": Object {
-          "character": 6,
-          "line": 205,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ver",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 15,
-          "line": 206,
-        },
-        "start": Object {
-          "character": 6,
-          "line": 206,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "isnpm10",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 21,
-          "line": 211,
-        },
-        "start": Object {
-          "character": 12,
-          "line": 211,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "isnpm10",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 21,
-          "line": 215,
-        },
-        "start": Object {
-          "character": 12,
-          "line": 215,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "isnpm10",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 22,
-          "line": 232,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 232,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "NODE",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 22,
-          "line": 235,
-        },
-        "start": Object {
-          "character": 10,
-          "line": 235,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "NODE",
   },
 ]
 `;

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -189,74 +189,6 @@ Array [
       "range": Object {
         "end": Object {
           "character": 6,
-          "line": 54,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 54,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 5,
-          "line": 83,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 83,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 6,
-          "line": 149,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 149,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 6,
-          "line": 181,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 181,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 6,
           "line": 265,
         },
         "start": Object {
@@ -267,23 +199,6 @@ Array [
       "uri": "dummy-uri.sh",
     },
     "name": "ret",
-  },
-  Object {
-    "kind": 13,
-    "location": Object {
-      "range": Object {
-        "end": Object {
-          "character": 15,
-          "line": 69,
-        },
-        "start": Object {
-          "character": 0,
-          "line": 69,
-        },
-      },
-      "uri": "dummy-uri.sh",
-    },
-    "name": "TMP",
   },
   Object {
     "kind": 13,

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -60,12 +60,6 @@ describe('analyze', () => {
 })
 
 describe('findDefinition', () => {
-  it('returns an empty list if word is not found', () => {
-    analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
-    const result = analyzer.findDefinition({ uri: CURRENT_URI, word: 'foobar' })
-    expect(result).toEqual([])
-  })
-
   it('returns a location to a file if word is the path in a sourcing statement', () => {
     const document = FIXTURE_DOCUMENT.SOURCING
     const { uri } = document
@@ -131,13 +125,13 @@ describe('findDefinition', () => {
     `)
   })
 
-  it('returns a list of locations if parameter is found', () => {
+  it('returns a local reference if definition is found', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
     const result = analyzer.findDefinition({
+      position: { character: 1, line: 148 },
       uri: CURRENT_URI,
       word: 'node_version',
     })
-    expect(result).not.toEqual([])
     expect(result).toMatchInlineSnapshot(`
       Array [
         Object {
@@ -152,6 +146,32 @@ describe('findDefinition', () => {
             },
           },
           "uri": "dummy-uri.sh",
+        },
+      ]
+    `)
+  })
+
+  it('returns local declarations', () => {
+    analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
+    const result = analyzer.findDefinition({
+      position: { character: 12, line: 12 },
+      uri: FIXTURE_URI.SCOPE,
+      word: 'X',
+    })
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 17,
+              "line": 11,
+            },
+            "start": Object {
+              "character": 10,
+              "line": 11,
+            },
+          },
+          "uri": "file://${FIXTURE_FOLDER}scope.sh",
         },
       ]
     `)

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -623,8 +623,29 @@ describe('findDeclarationsMatchingWord', () => {
       ]
     `)
 
-    // FIXME: this should return the a reference to the function
-    expect(findWordFromLine('GLOBAL_1', 1000)).toHaveLength(1)
+    // Global variable defined inside a function
+    expect(findWordFromLine('GLOBAL_1', 1000)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "containerName": "g",
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 23,
+                "line": 13,
+              },
+              "start": Object {
+                "character": 4,
+                "line": 13,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "GLOBAL_1",
+        },
+      ]
+    `)
   })
 })
 

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -318,6 +318,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'npm_config_logl',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
+        position: { line: 1000, character: 0 },
       }),
     ).toMatchInlineSnapshot(`
       Array [
@@ -363,6 +364,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'xxxxxxxx',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
+        position: { line: 1000, character: 0 },
       }),
     ).toMatchInlineSnapshot(`Array []`)
 
@@ -371,6 +373,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'BLU',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
+        position: { line: 6, character: 9 },
       }),
     ).toMatchInlineSnapshot(`
       Array [
@@ -399,6 +402,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'BLU',
         uri: FIXTURE_URI.SOURCING,
         exactMatch: false,
+        position: { line: 6, character: 9 },
       }),
     ).toMatchInlineSnapshot(`
       Array [
@@ -443,6 +447,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'BLU',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
+        position: { line: 1000, character: 0 },
       }),
     ).toMatchInlineSnapshot(`Array []`)
 
@@ -451,6 +456,7 @@ describe('findSymbolsMatchingWord', () => {
         word: 'BLU',
         uri: FIXTURE_URI.SOURCING,
         exactMatch: false,
+        position: { line: 6, character: 9 },
       }),
     ).toMatchInlineSnapshot(`
       Array [

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -410,7 +410,7 @@ describe('findSymbolsMatchingWord', () => {
     `)
   })
 
-  it('return a list of symbols accessible to the uri when includeAllWorkspaceSymbols is false', async () => {
+  it('returns a list of symbols accessible to the uri when includeAllWorkspaceSymbols is false', async () => {
     const parser = await initializeParser()
     const connection = getMockConnection()
 
@@ -459,6 +459,146 @@ describe('findSymbolsMatchingWord', () => {
             "uri": "file://${FIXTURE_FOLDER}extension.inc",
           },
           "name": "BLUE",
+        },
+      ]
+    `)
+  })
+
+  it('returns symbols depending on the scope', async () => {
+    const parser = await initializeParser()
+    const connection = getMockConnection()
+
+    const analyzer = new Analyzer({
+      console: connection.console,
+      parser,
+      includeAllWorkspaceSymbols: false,
+      workspaceFolder: FIXTURE_FOLDER,
+    })
+
+    const findWordFromLine = (word: string, line: number) =>
+      analyzer.findSymbolsMatchingWord({
+        word,
+        uri: FIXTURE_URI.SCOPE,
+        exactMatch: true,
+        position: { line, character: 0 },
+      })
+
+    // Variable or function defined yet
+    expect(findWordFromLine('X', 0)).toEqual([])
+    expect(findWordFromLine('f', 0)).toEqual([])
+
+    // First definition
+    expect(findWordFromLine('X', 3)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 9,
+                "line": 2,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 2,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "X",
+        },
+      ]
+    `)
+
+    // Local variable definition
+    expect(findWordFromLine('X', 13)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "containerName": "g",
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 17,
+                "line": 11,
+              },
+              "start": Object {
+                "character": 10,
+                "line": 11,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "X",
+        },
+      ]
+    `)
+
+    // Local function definition
+    expect(findWordFromLine('f', 20)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "containerName": "g",
+          "kind": 12,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 5,
+                "line": 18,
+              },
+              "start": Object {
+                "character": 4,
+                "line": 15,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "f",
+        },
+      ]
+    `)
+
+    // Last definition
+    expect(findWordFromLine('X', 1000)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "kind": 13,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 9,
+                "line": 4,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 4,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "X",
+        },
+      ]
+    `)
+
+    expect(findWordFromLine('f', 1000)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "kind": 12,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 1,
+                "line": 26,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 7,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}scope.sh",
+          },
+          "name": "f",
         },
       ]
     `)

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -762,7 +762,9 @@ describe('getAllVariableSymbols', () => {
 
     newAnalyzer.analyze({ uri, document })
 
-    expect(newAnalyzer.getAllVariableSymbols({ uri })).toMatchInlineSnapshot(`
+    expect(
+      newAnalyzer.getAllVariableSymbols({ uri, position: { line: 20, character: 0 } }),
+    ).toMatchInlineSnapshot(`
       Array [
         Object {
           "kind": 13,

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -18,7 +18,7 @@ const CURRENT_URI = 'dummy-uri.sh'
 const mockConsole = getMockConnection().console
 
 // if you add a .sh file to testing/fixtures, update this value
-const FIXTURE_FILES_MATCHING_GLOB = 14
+const FIXTURE_FILES_MATCHING_GLOB = 15
 
 const defaultConfig = getDefaultConfiguration()
 
@@ -298,7 +298,7 @@ describe('commandNameAtPoint', () => {
 })
 
 describe('findSymbolsMatchingWord', () => {
-  it('return a list of symbols across the workspace when includeAllWorkspaceSymbols is true', async () => {
+  it('returns a list of symbols across the workspace when includeAllWorkspaceSymbols is true', async () => {
     const parser = await initializeParser()
     const connection = getMockConnection()
 
@@ -333,23 +333,6 @@ describe('findSymbolsMatchingWord', () => {
               "start": Object {
                 "character": 0,
                 "line": 40,
-              },
-            },
-            "uri": "file://${FIXTURE_FOLDER}install.sh",
-          },
-          "name": "npm_config_loglevel",
-        },
-        Object {
-          "kind": 13,
-          "location": Object {
-            "range": Object {
-              "end": Object {
-                "character": 31,
-                "line": 48,
-              },
-              "start": Object {
-                "character": 2,
-                "line": 48,
               },
             },
             "uri": "file://${FIXTURE_FOLDER}install.sh",
@@ -722,24 +705,6 @@ describe('getAllVariableSymbols', () => {
             "uri": "file://${FIXTURE_FOLDER}extension.inc",
           },
           "name": "RESET",
-        },
-        Object {
-          "containerName": "tagRelease",
-          "kind": 13,
-          "location": Object {
-            "range": Object {
-              "end": Object {
-                "character": 8,
-                "line": 5,
-              },
-              "start": Object {
-                "character": 2,
-                "line": 5,
-              },
-            },
-            "uri": "file://${REPO_ROOT_FOLDER}/scripts/tag-release.inc",
-          },
-          "name": "tag",
         },
       ]
     `)

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -164,11 +164,11 @@ describe('findDeclarationLocations', () => {
           "range": Object {
             "end": Object {
               "character": 17,
-              "line": 11,
+              "line": 12,
             },
             "start": Object {
               "character": 10,
-              "line": 11,
+              "line": 12,
             },
           },
           "uri": "file://${FIXTURE_FOLDER}scope.sh",
@@ -540,11 +540,11 @@ describe('findDeclarationsMatchingWord', () => {
             "range": Object {
               "end": Object {
                 "character": 17,
-                "line": 11,
+                "line": 12,
               },
               "start": Object {
                 "character": 10,
-                "line": 11,
+                "line": 12,
               },
             },
             "uri": "file://${FIXTURE_FOLDER}scope.sh",
@@ -555,7 +555,7 @@ describe('findDeclarationsMatchingWord', () => {
     `)
 
     // Local function definition
-    expect(findWordFromLine('f', 20)).toMatchInlineSnapshot(`
+    expect(findWordFromLine('f', 23)).toMatchInlineSnapshot(`
       Array [
         Object {
           "containerName": "g",
@@ -564,11 +564,11 @@ describe('findDeclarationsMatchingWord', () => {
             "range": Object {
               "end": Object {
                 "character": 5,
-                "line": 18,
+                "line": 21,
               },
               "start": Object {
                 "character": 4,
-                "line": 15,
+                "line": 18,
               },
             },
             "uri": "file://${FIXTURE_FOLDER}scope.sh",
@@ -609,7 +609,7 @@ describe('findDeclarationsMatchingWord', () => {
             "range": Object {
               "end": Object {
                 "character": 1,
-                "line": 26,
+                "line": 30,
               },
               "start": Object {
                 "character": 0,
@@ -622,6 +622,9 @@ describe('findDeclarationsMatchingWord', () => {
         },
       ]
     `)
+
+    // FIXME: this should return the a reference to the function
+    expect(findWordFromLine('GLOBAL_1', 1000)).toHaveLength(1)
   })
 })
 

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -59,12 +59,12 @@ describe('analyze', () => {
   })
 })
 
-describe('findDefinition', () => {
+describe('findDeclarationLocations', () => {
   it('returns a location to a file if word is the path in a sourcing statement', () => {
     const document = FIXTURE_DOCUMENT.SOURCING
     const { uri } = document
     analyzer.analyze({ uri, document })
-    const result = analyzer.findDefinition({
+    const result = analyzer.findDeclarationLocations({
       uri,
       word: './extension.inc',
       position: { character: 10, line: 2 },
@@ -101,7 +101,7 @@ describe('findDefinition', () => {
     })
 
     newAnalyzer.analyze({ uri, document })
-    const result = newAnalyzer.findDefinition({
+    const result = newAnalyzer.findDeclarationLocations({
       uri,
       word: './scripts/tag-release.inc',
       position: { character: 10, line: 16 },
@@ -127,7 +127,7 @@ describe('findDefinition', () => {
 
   it('returns a local reference if definition is found', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
-    const result = analyzer.findDefinition({
+    const result = analyzer.findDeclarationLocations({
       position: { character: 1, line: 148 },
       uri: CURRENT_URI,
       word: 'node_version',
@@ -153,7 +153,7 @@ describe('findDefinition', () => {
 
   it('returns local declarations', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
-    const result = analyzer.findDefinition({
+    const result = analyzer.findDeclarationLocations({
       position: { character: 12, line: 12 },
       uri: FIXTURE_URI.SCOPE,
       word: 'X',
@@ -193,23 +193,23 @@ describe('findReferences', () => {
   })
 })
 
-describe('findSymbolsForFile', () => {
+describe('getDeclarationsForUri', () => {
   it('returns empty list if uri is not found', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
-    const result = analyzer.findSymbolsForFile({ uri: 'foobar.sh' })
+    const result = analyzer.getDeclarationsForUri({ uri: 'foobar.sh' })
     expect(result).toEqual([])
   })
 
   it('returns a list of SymbolInformation if uri is found', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.INSTALL })
-    const result = analyzer.findSymbolsForFile({ uri: CURRENT_URI })
+    const result = analyzer.getDeclarationsForUri({ uri: CURRENT_URI })
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
 
   it('issue 101', () => {
     analyzer.analyze({ uri: CURRENT_URI, document: FIXTURE_DOCUMENT.ISSUE101 })
-    const result = analyzer.findSymbolsForFile({ uri: CURRENT_URI })
+    const result = analyzer.getDeclarationsForUri({ uri: CURRENT_URI })
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
@@ -317,7 +317,7 @@ describe('commandNameAtPoint', () => {
   })
 })
 
-describe('findSymbolsMatchingWord', () => {
+describe('findDeclarationsMatchingWord', () => {
   it('returns a list of symbols across the workspace when includeAllWorkspaceSymbols is true', async () => {
     const parser = await initializeParser()
     const connection = getMockConnection()
@@ -334,7 +334,7 @@ describe('findSymbolsMatchingWord', () => {
     })
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'npm_config_logl',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
@@ -363,7 +363,7 @@ describe('findSymbolsMatchingWord', () => {
     `)
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'xxxxxxxx',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
@@ -372,7 +372,7 @@ describe('findSymbolsMatchingWord', () => {
     ).toMatchInlineSnapshot(`Array []`)
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'BLU',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
@@ -401,7 +401,7 @@ describe('findSymbolsMatchingWord', () => {
     `)
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'BLU',
         uri: FIXTURE_URI.SOURCING,
         exactMatch: false,
@@ -446,7 +446,7 @@ describe('findSymbolsMatchingWord', () => {
     })
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'BLU',
         uri: FIXTURE_URI.INSTALL,
         exactMatch: false,
@@ -455,7 +455,7 @@ describe('findSymbolsMatchingWord', () => {
     ).toMatchInlineSnapshot(`Array []`)
 
     expect(
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word: 'BLU',
         uri: FIXTURE_URI.SOURCING,
         exactMatch: false,
@@ -496,7 +496,7 @@ describe('findSymbolsMatchingWord', () => {
     })
 
     const findWordFromLine = (word: string, line: number) =>
-      analyzer.findSymbolsMatchingWord({
+      analyzer.findDeclarationsMatchingWord({
         word,
         uri: FIXTURE_URI.SCOPE,
         exactMatch: true,
@@ -745,7 +745,7 @@ describe('initiateBackgroundAnalysis', () => {
   })
 })
 
-describe('getAllVariableSymbols', () => {
+describe('getAllVariables', () => {
   it('returns all variable symbols', async () => {
     const document = FIXTURE_DOCUMENT.SOURCING
     const { uri } = document
@@ -762,9 +762,8 @@ describe('getAllVariableSymbols', () => {
 
     newAnalyzer.analyze({ uri, document })
 
-    expect(
-      newAnalyzer.getAllVariableSymbols({ uri, position: { line: 20, character: 0 } }),
-    ).toMatchInlineSnapshot(`
+    expect(newAnalyzer.getAllVariables({ uri, position: { line: 20, character: 0 } }))
+      .toMatchInlineSnapshot(`
       Array [
         Object {
           "kind": 13,

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -274,7 +274,7 @@ describe('server', () => {
         },
         position: {
           // X
-          line: 28,
+          line: 32,
           character: 8,
         },
       },
@@ -324,22 +324,10 @@ describe('server', () => {
           "range": Object {
             "end": Object {
               "character": 11,
-              "line": 11,
+              "line": 12,
             },
             "start": Object {
               "character": 10,
-              "line": 11,
-            },
-          },
-        },
-        Object {
-          "range": Object {
-            "end": Object {
-              "character": 13,
-              "line": 12,
-            },
-            "start": Object {
-              "character": 12,
               "line": 12,
             },
           },
@@ -348,11 +336,23 @@ describe('server', () => {
           "range": Object {
             "end": Object {
               "character": 13,
-              "line": 16,
+              "line": 15,
             },
             "start": Object {
               "character": 12,
-              "line": 16,
+              "line": 15,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 13,
+              "line": 19,
+            },
+            "start": Object {
+              "character": 12,
+              "line": 19,
             },
           },
         },
@@ -360,11 +360,11 @@ describe('server', () => {
           "range": Object {
             "end": Object {
               "character": 15,
-              "line": 17,
+              "line": 20,
             },
             "start": Object {
               "character": 14,
-              "line": 17,
+              "line": 20,
             },
           },
         },
@@ -372,11 +372,11 @@ describe('server', () => {
           "range": Object {
             "end": Object {
               "character": 11,
-              "line": 25,
+              "line": 29,
             },
             "start": Object {
               "character": 10,
-              "line": 25,
+              "line": 29,
             },
           },
         },
@@ -384,11 +384,11 @@ describe('server', () => {
           "range": Object {
             "end": Object {
               "character": 9,
-              "line": 28,
+              "line": 32,
             },
             "start": Object {
               "character": 8,
-              "line": 28,
+              "line": 32,
             },
           },
         },

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -849,30 +849,27 @@ describe('server', () => {
     `)
   })
 
-  it.failing(
-    'returns executable documentation if the function is not redefined',
-    async () => {
-      const { connection, server } = await initializeServer()
-      server.register(connection)
+  it('returns executable documentation if the function is not redefined', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
 
-      const onHover = connection.onHover.mock.calls[0][0]
+    const onHover = connection.onHover.mock.calls[0][0]
 
-      const result = await onHover(
-        {
-          textDocument: {
-            uri: FIXTURE_URI.OVERRIDE_SYMBOL,
-          },
-          position: {
-            line: 2,
-            character: 1,
-          },
+    const result = await onHover(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.OVERRIDE_SYMBOL,
         },
-        {} as any,
-        {} as any,
-      )
+        position: {
+          line: 2,
+          character: 1,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
 
-      expect(result).toBeDefined()
-      expect((result as any)?.contents.value).toContain('ls – list directory contents')
-    },
-  )
+    expect(result).toBeDefined()
+    expect((result as any)?.contents.value).toContain('ls – list directory contents')
+  })
 })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -669,58 +669,6 @@ describe('server', () => {
           "kind": 6,
           "label": "RESET",
         },
-        Object {
-          "data": Object {
-            "name": "USER",
-            "type": 3,
-          },
-          "documentation": Object {
-            "kind": "markdown",
-            "value": "Variable: **USER** - *defined in issue101.sh*",
-          },
-          "kind": 6,
-          "label": "USER",
-        },
-        Object {
-          "data": Object {
-            "name": "PASSWORD",
-            "type": 3,
-          },
-          "documentation": Object {
-            "kind": "markdown",
-            "value": "Variable: **PASSWORD** - *defined in issue101.sh*",
-          },
-          "kind": 6,
-          "label": "PASSWORD",
-        },
-        Object {
-          "data": Object {
-            "name": "COMMENTS",
-            "type": 3,
-          },
-          "documentation": Object {
-            "kind": "markdown",
-            "value": "Variable: **COMMENTS** - *defined in issue101.sh*
-
-      \`\`\`txt
-      Having shifted twice, the rest is now comments ...
-      \`\`\`",
-          },
-          "kind": 6,
-          "label": "COMMENTS",
-        },
-        Object {
-          "data": Object {
-            "name": "tag",
-            "type": 3,
-          },
-          "documentation": Object {
-            "kind": "markdown",
-            "value": "Variable: **tag** - *defined in ../../scripts/tag-release.inc*",
-          },
-          "kind": 6,
-          "label": "tag",
-        },
       ]
     `)
   })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -221,21 +221,8 @@ describe('server', () => {
       {} as any,
     )
 
-    // TODO: there is a superfluous range here on line 0:
     expect(result1).toMatchInlineSnapshot(`
       Array [
-        Object {
-          "range": Object {
-            "end": Object {
-              "character": 12,
-              "line": 0,
-            },
-            "start": Object {
-              "character": 9,
-              "line": 0,
-            },
-          },
-        },
         Object {
           "range": Object {
             "end": Object {
@@ -279,6 +266,134 @@ describe('server', () => {
     )
 
     expect(result2).toMatchInlineSnapshot(`Array []`)
+
+    const result3 = await onDocumentHighlight(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.SCOPE,
+        },
+        position: {
+          // X
+          line: 28,
+          character: 8,
+        },
+      },
+      {} as any,
+      {} as any,
+    )
+
+    expect(result3).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 1,
+              "line": 2,
+            },
+            "start": Object {
+              "character": 0,
+              "line": 2,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 1,
+              "line": 4,
+            },
+            "start": Object {
+              "character": 0,
+              "line": 4,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 9,
+              "line": 8,
+            },
+            "start": Object {
+              "character": 8,
+              "line": 8,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 11,
+              "line": 11,
+            },
+            "start": Object {
+              "character": 10,
+              "line": 11,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 13,
+              "line": 12,
+            },
+            "start": Object {
+              "character": 12,
+              "line": 12,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 13,
+              "line": 16,
+            },
+            "start": Object {
+              "character": 12,
+              "line": 16,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 15,
+              "line": 17,
+            },
+            "start": Object {
+              "character": 14,
+              "line": 17,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 11,
+              "line": 25,
+            },
+            "start": Object {
+              "character": 10,
+              "line": 25,
+            },
+          },
+        },
+        Object {
+          "range": Object {
+            "end": Object {
+              "character": 9,
+              "line": 28,
+            },
+            "start": Object {
+              "character": 8,
+              "line": 28,
+            },
+          },
+        },
+      ]
+    `)
   })
 
   it('responds to onWorkspaceSymbol', async () => {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -922,6 +922,6 @@ describe('server', () => {
     )
 
     expect(result).toBeDefined()
-    expect((result as any)?.contents.value).toContain('ls – list directory contents')
+    expect((result as any)?.contents.value).toContain('list directory contents')
   })
 })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -307,17 +307,6 @@ describe('server', () => {
           },
           name: 'npm_config_loglevel',
         },
-        {
-          kind: expect.any(Number),
-          location: {
-            range: {
-              end: { character: 31, line: 48 },
-              start: { character: 2, line: 48 },
-            },
-            uri: expect.stringContaining('/testing/fixtures/install.sh'),
-          },
-          name: 'npm_config_loglevel',
-        },
       ])
     }
 

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -321,7 +321,7 @@ export default class Analyzer {
     exactMatch: boolean
     uri: string
     word: string
-    position?: LSP.Position // FIXME: rename to location
+    position: LSP.Position // FIXME: rename to location
   }): LSP.SymbolInformation[] {
     return this.getReachableUris({ uri: fromUri }).reduce((symbols, uri) => {
       const analyzedDocument = this.uriToAnalyzedDocument[uri]
@@ -336,7 +336,7 @@ export default class Analyzer {
               // Skip if the symbol is defined in the current file after the requested position
               // Ideally we want to be a lot smarter here...
               if (uri === fromUri) {
-                if (position && symbol.location.range.start.line > position.line) {
+                if (symbol.location.range.start.line > position.line) {
                   return
                 }
               }

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -149,7 +149,7 @@ export default class Analyzer {
     uri,
     word,
   }: {
-    position?: { line: number; character: number }
+    position: LSP.Position
     uri: string
     word: string
   }): LSP.Location[] {
@@ -169,18 +169,12 @@ export default class Analyzer {
       }
     }
 
-    return this.getReachableUris({ uri })
-      .reduce((symbols, uri) => {
-        const analyzedDocument = this.uriToAnalyzedDocument[uri]
-        if (analyzedDocument) {
-          const globalDeclaration = analyzedDocument.globalDeclarations[word]
-          if (globalDeclaration) {
-            symbols.push(globalDeclaration)
-          }
-        }
-        return symbols
-      }, [] as LSP.SymbolInformation[])
-      .map((symbol) => symbol.location)
+    return this.findSymbolsMatchingWord({
+      exactMatch: true,
+      position,
+      uri,
+      word,
+    }).map((symbol) => symbol.location)
   }
 
   /**
@@ -253,7 +247,7 @@ export default class Analyzer {
   }
 
   /**
-   * Find all the locations where something named name has been defined.
+   * Find all the locations where something named name has been defined or referenced.
    *
    * FIXME: take position into account
    * FIXME: take file into account
@@ -316,9 +310,10 @@ export default class Analyzer {
   }
 
   /**
-   * Find symbol completions for the given word.
+   * Find declarations/definitions for the given word.
    *
    * FIXME: could this use findAllSymbols?
+   * FIXME: rename to findDeclarationsMatchingWord
    */
   public findSymbolsMatchingWord({
     exactMatch,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -474,6 +474,9 @@ export default class BashServer {
   }
 
   private onDocumentSymbol(params: LSP.DocumentSymbolParams): LSP.SymbolInformation[] {
+    // FIXME: ideally this should return LSP.DocumentSymbol[] instead of LSP.SymbolInformation[]
+    // which is a hirearchy of symbols.
+    // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol
     this.connection.console.log(`onDocumentSymbol`)
     return this.analyzer.findSymbolsForFile({ uri: params.textDocument.uri })
   }
@@ -559,7 +562,10 @@ export default class BashServer {
         ? []
         : this.getCompletionItemsForSymbols({
             symbols: shouldCompleteOnVariables
-              ? this.analyzer.getAllVariableSymbols({ uri: currentUri })
+              ? this.analyzer.getAllVariableSymbols({
+                  uri: currentUri,
+                  position: params.position,
+                })
               : this.analyzer.findSymbolsMatchingWord({
                   exactMatch: false,
                   uri: currentUri,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -564,6 +564,7 @@ export default class BashServer {
                   exactMatch: false,
                   uri: currentUri,
                   word,
+                  position: params.position,
                 }),
             currentUri,
           })

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -430,6 +430,7 @@ export default class BashServer {
       exactMatch: true,
       uri: currentUri,
       word,
+      position: params.position,
     })
     if (
       ReservedWords.isReservedWord(word) ||

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -474,7 +474,7 @@ export default class BashServer {
   }
 
   private onDocumentSymbol(params: LSP.DocumentSymbolParams): LSP.SymbolInformation[] {
-    // FIXME: ideally this should return LSP.DocumentSymbol[] instead of LSP.SymbolInformation[]
+    // TODO: ideally this should return LSP.DocumentSymbol[] instead of LSP.SymbolInformation[]
     // which is a hierarchy of symbols.
     // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol
     this.connection.console.log(`onDocumentSymbol`)

--- a/server/src/util/__tests__/flatten.test.ts
+++ b/server/src/util/__tests__/flatten.test.ts
@@ -1,4 +1,4 @@
-import { flattenArray, flattenObjectValues } from '../flatten'
+import { flattenArray } from '../flatten'
 
 describe('flattenArray', () => {
   it('works on array with one element', () => {
@@ -7,16 +7,5 @@ describe('flattenArray', () => {
 
   it('works on array with multiple elements', () => {
     expect(flattenArray([[1], [2, 3], [4]])).toEqual([1, 2, 3, 4])
-  })
-})
-
-describe('flattenObjectValues', () => {
-  it('flatten object values', () => {
-    expect(
-      flattenObjectValues({
-        'foo.sh': [1],
-        'baz.sh': [2],
-      }),
-    ).toEqual([1, 2])
   })
 })

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -37,11 +37,7 @@ export function getGlobalDeclarations({
   const diagnostics: LSP.Diagnostic[] = []
   const globalDeclarations: GlobalDeclarations = {}
 
-  TreeSitterUtil.forEach(tree.rootNode, (node: Parser.SyntaxNode) => {
-    if (node.parent?.type !== 'program') {
-      return
-    }
-
+  tree.rootNode.children.forEach((node) => {
     if (node.type === 'ERROR') {
       diagnostics.push(
         LSP.Diagnostic.create(
@@ -61,8 +57,6 @@ export function getGlobalDeclarations({
         globalDeclarations[word] = symbol
       }
     }
-
-    return
   })
 
   return { diagnostics, globalDeclarations }

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -10,6 +10,7 @@ const TREE_SITTER_TYPE_TO_LSP_KIND: { [type: string]: LSP.SymbolKind | undefined
   variable_assignment: LSP.SymbolKind.Variable,
 }
 
+export type GlobalDeclarations = { [word: string]: LSP.SymbolInformation }
 export type Declarations = { [word: string]: LSP.SymbolInformation[] }
 
 /**
@@ -29,9 +30,12 @@ export function getGlobalDeclarations({
 }: {
   tree: Parser.Tree
   uri: string
-}): { diagnostics: LSP.Diagnostic[]; declarations: Declarations } {
+}): {
+  diagnostics: LSP.Diagnostic[]
+  globalDeclarations: GlobalDeclarations
+} {
   const diagnostics: LSP.Diagnostic[] = []
-  const declarations: Declarations = {}
+  const globalDeclarations: GlobalDeclarations = {}
 
   TreeSitterUtil.forEach(tree.rootNode, (node: Parser.SyntaxNode) => {
     if (node.parent?.type !== 'program') {
@@ -54,14 +58,14 @@ export function getGlobalDeclarations({
 
       if (symbol) {
         const word = symbol.name
-        declarations[word] = [symbol] // TODO: ensure this is the latest definition
+        globalDeclarations[word] = symbol
       }
     }
 
     return
   })
 
-  return { diagnostics, declarations }
+  return { diagnostics, globalDeclarations }
 }
 
 function nodeToSymbolInformation({

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -132,7 +132,6 @@ export function getLocalDeclarations({
             })
           }
         } else if (TreeSitterUtil.isDefinition(childNode)) {
-          // FIXME: does this also capture local variables?
           symbol = nodeToSymbolInformation({ node: childNode, uri })
         }
 

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -94,6 +94,9 @@ export function getAllDeclarationsInTree({
  * Done by traversing the tree upwards (which is a simplification for
  * actual bash behaviour but deemed good enough, compared to the complexity of flow tracing).
  * Filters out duplicate definitions. Used when getting declarations for the current scope.
+ *
+ * FIXME: unfortunately this doesn't capture all global variables defined inside functions.
+ * Wondering if getGlobalDeclarations should return this or we should make that a custom feature of this function.
  */
 export function getLocalDeclarations({
   node,

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -1,0 +1,150 @@
+import * as LSP from 'vscode-languageserver/node'
+import * as Parser from 'web-tree-sitter'
+
+import * as TreeSitterUtil from './tree-sitter'
+
+const TREE_SITTER_TYPE_TO_LSP_KIND: { [type: string]: LSP.SymbolKind | undefined } = {
+  // These keys are using underscores as that's the naming convention in tree-sitter.
+  environment_variable_assignment: LSP.SymbolKind.Variable,
+  function_definition: LSP.SymbolKind.Function,
+  variable_assignment: LSP.SymbolKind.Variable,
+}
+
+export type Declarations = { [word: string]: LSP.SymbolInformation[] }
+
+/**
+ * Returns declarations (functions or variables) from a given root node
+ * that would be available after sourcing the file.
+ *
+ * Will only return one declaration per symbol name – the latest definition.
+ * This behavior is consistent with how Bash behaves, but differs between
+ * LSP servers.
+ *
+ * Used when finding declarations for sourced files and to get declarations
+ * for the entire workspace.
+ */
+export function getGlobalDeclarations({
+  tree,
+  uri,
+}: {
+  tree: Parser.Tree
+  uri: string
+}): { diagnostics: LSP.Diagnostic[]; declarations: Declarations } {
+  const diagnostics: LSP.Diagnostic[] = []
+  const declarations: Declarations = {}
+
+  TreeSitterUtil.forEach(tree.rootNode, (node: Parser.SyntaxNode) => {
+    if (node.parent?.type !== 'program') {
+      return
+    }
+
+    if (node.type === 'ERROR') {
+      diagnostics.push(
+        LSP.Diagnostic.create(
+          TreeSitterUtil.range(node),
+          'Failed to parse',
+          LSP.DiagnosticSeverity.Error,
+        ),
+      )
+      return
+    }
+
+    if (TreeSitterUtil.isDefinition(node)) {
+      const symbol = nodeToSymbolInformation({ node, uri })
+
+      if (symbol) {
+        const word = symbol.name
+        declarations[word] = [symbol] // TODO: ensure this is the latest definition
+      }
+    }
+
+    return
+  })
+
+  return { diagnostics, declarations }
+}
+
+function nodeToSymbolInformation({
+  node,
+  uri,
+}: {
+  node: Parser.SyntaxNode
+  uri: string
+}): LSP.SymbolInformation | null {
+  const named = node.firstNamedChild
+
+  if (named === null) {
+    return null
+  }
+
+  const containerName =
+    TreeSitterUtil.findParent(node, (p) => p.type === 'function_definition')
+      ?.firstNamedChild?.text || ''
+
+  const kind = TREE_SITTER_TYPE_TO_LSP_KIND[node.type]
+
+  return LSP.SymbolInformation.create(
+    named.text,
+    kind || LSP.SymbolKind.Variable,
+    TreeSitterUtil.range(node),
+    uri,
+    containerName,
+  )
+}
+
+/**
+ * Returns declarations available for the given file and location
+ * Done by traversing the tree upwards (which is a simplification for
+ * actual bash behaviour but deemed good enough, compared to the complexity of flow tracing).
+ * Filters out duplicate definitions. Used when getting declarations for the current scope.
+ */
+export function getLocalDeclarations({
+  node,
+  uri,
+}: {
+  node: Parser.SyntaxNode | null
+  uri: string
+}): Declarations {
+  const declarations: Declarations = {}
+
+  // bottom up traversal of the tree to capture all local declarations
+
+  const walk = (node: Parser.SyntaxNode | null) => {
+    // NOTE: there is also node.walk
+    if (node) {
+      for (const childNode of node.children) {
+        let symbol: LSP.SymbolInformation | null = null
+
+        // local variables
+        if (childNode.type === 'declaration_command') {
+          const variableAssignmentNode = childNode.children.filter(
+            (child) => child.type === 'variable_assignment',
+          )[0]
+
+          if (variableAssignmentNode) {
+            symbol = nodeToSymbolInformation({
+              node: variableAssignmentNode,
+              uri,
+            })
+          }
+        } else if (TreeSitterUtil.isDefinition(childNode)) {
+          // FIXME: does this also capture local variables?
+          symbol = nodeToSymbolInformation({ node: childNode, uri })
+        }
+
+        if (symbol) {
+          if (!declarations[symbol.name]) {
+            declarations[symbol.name] = []
+          }
+          declarations[symbol.name].push(symbol)
+        }
+      }
+
+      walk(node.parent)
+    }
+  }
+
+  walk(node)
+
+  return declarations
+}

--- a/server/src/util/flatten.ts
+++ b/server/src/util/flatten.ts
@@ -1,7 +1,3 @@
 export function flattenArray<T>(nestedArray: T[][]): T[] {
   return nestedArray.reduce((acc, array) => [...acc, ...array], [])
 }
-
-export function flattenObjectValues<T>(object: { [key: string]: T[] }): T[] {
-  return flattenArray(Object.keys(object).map((objectKey) => object[objectKey]))
-}

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -16,17 +16,18 @@ function getDocument(uri: string) {
 type FIXTURE_KEY = keyof typeof FIXTURE_URI
 
 export const FIXTURE_URI = {
+  COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`,
   INSTALL: `file://${path.join(FIXTURE_FOLDER, 'install.sh')}`,
   ISSUE101: `file://${path.join(FIXTURE_FOLDER, 'issue101.sh')}`,
   ISSUE206: `file://${path.join(FIXTURE_FOLDER, 'issue206.sh')}`,
   MISSING_EXTENSION: `file://${path.join(FIXTURE_FOLDER, 'extension')}`,
   MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
-  PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
-  SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
-  COMMENT_DOC: `file://${path.join(FIXTURE_FOLDER, 'comment-doc-on-hover.sh')}`,
   OPTIONS: `file://${path.join(FIXTURE_FOLDER, 'options.sh')}`,
-  SHELLCHECK_SOURCE: `file://${path.join(FIXTURE_FOLDER, 'shellcheck', 'source.sh')}`,
   OVERRIDE_SYMBOL: `file://${path.join(FIXTURE_FOLDER, 'override-executable-symbol.sh')}`,
+  PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,
+  SCOPE: `file://${path.join(FIXTURE_FOLDER, 'scope.sh')}`,
+  SHELLCHECK_SOURCE: `file://${path.join(FIXTURE_FOLDER, 'shellcheck', 'source.sh')}`,
+  SOURCING: `file://${path.join(FIXTURE_FOLDER, 'sourcing.sh')}`,
 }
 
 export const FIXTURE_DOCUMENT: Record<FIXTURE_KEY, TextDocument> = (

--- a/testing/fixtures/extension.inc
+++ b/testing/fixtures/extension.inc
@@ -7,3 +7,11 @@ GREEN=`tput setaf 2`
 BLUE=`tput setaf 4`
 BOLD=`tput bold`
 RESET=`tput sgr0`
+
+extensionFunc() {
+  LOCAL_VARIABLE='local'
+
+  innerExtensionFunc() {
+    echo $LOCAL_VARIABLE
+  }
+}

--- a/testing/fixtures/scope.sh
+++ b/testing/fixtures/scope.sh
@@ -7,9 +7,12 @@ X="Mouse"
 # some function
 f() (
   local X="Dog"
+  GLOBAL_1="Global 1"
 
   g() {
     local X="Cat"
+    GLOBAL_1="Global 1"
+    GLOBAL_2="Global 1"
     echo "${X}"
 
     # another function function
@@ -23,8 +26,11 @@ f() (
 
   g
 
+  echo "${GLOBAL_1}"
   echo "${X}"
 )
 
 echo "${X}"
 f
+
+echo "${GLOBAL_2}"

--- a/testing/fixtures/scope.sh
+++ b/testing/fixtures/scope.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+X="Horse"
+
+X="Mouse"
+
+# some function
+f() (
+  local X="Dog"
+
+  g() {
+    local X="Cat"
+    echo "${X}"
+
+    # another function function
+    f() {
+      local X="Bird"
+      echo "${X}"
+    }
+
+    f
+  }
+
+  g
+
+  echo "${X}"
+)
+
+echo "${X}"
+f


### PR DESCRIPTION
Resolves #220 https://github.com/bash-lsp/bash-language-server/issues/318 https://github.com/bash-lsp/bash-language-server/issues/318 https://github.com/bash-lsp/bash-language-server/issues/515

When auto-completing on symbols or using jumping to definition, the server currently uses a simple and faulty heuristic of using all symbols available in the file and sourced files.

This PR introduces a better heuristic of taking the scope into account, both locally and when sourcing files. This means:
- jump to definition is improved across files: jump to the latest definition in a sourced file, and never to inaccessible local scoped variables
- local variables are only suggested when available 
- jump to definition is always using the latest definition of a symbol

Related https://github.com/bash-lsp/bash-language-server/issues/548
