### PR TITLE
Stop wasting CPU cycles and memory for large workspaces

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -3,7 +3,7 @@
 There are two moving parts.
 
 - **Server**: A node server written in Typescript that implements the
-  [Language Server Protocol (LSP)][LSP].
+  [Language Server Protocol (LSP)][lsp].
 
 **Client**: A Visual Studio Code (vscode) extension which wraps the LSP server.
 
@@ -75,7 +75,6 @@ yarn link-server
 
 After that follow the steps above to work on the client.
 
-
 ## Working on the server (standalone)
 
 If you are working on the server outside of VS Code, then simply compile
@@ -86,7 +85,14 @@ reload your vscode window to re-launch the server.
 yarn run reinstall-server
 ```
 
-[LSP]: https://microsoft.github.io/language-server-protocol/
+## Performance
+
+To analyze the performance of the extension or server using the Chrome inspector:
+
+1. In Code start debugging "Run -> Start debugging"
+2. Open `chrome://inspect` in Chrome and ensure the port `localhost:6009` is added
+
+[lsp]: https://microsoft.github.io/language-server-protocol/
 [ide-bash]: https://github.com/bash-lsp/ide-bash
 [jest]: https://facebook.github.io/jest/
 [prettier]: https://prettier.io/

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.2.5
+
+- Fix a critical bug causing memory leaks and high CPU usage for workspaces with many files https://github.com/bash-lsp/bash-language-server/pull/661
+
 ## 4.2.4
 
 - Increase ShellCheck execution delay to 500ms after typing ends.

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -39,6 +39,8 @@ export async function getFilePaths({
   let i = 0
   for await (const fileEntry of stream) {
     if (i >= maxItems) {
+      // NOTE: Close the stream to stop reading files paths.
+      stream.emit('close')
       break
     }
 


### PR DESCRIPTION
Even though we limited the background analysis through the `backgroundAnalysisMaxFiles` config option, the globbing library actually silently continued to find additional files matching the given glob – causing out of memory exceptions and wasting a lot of CPU cycles.

This is now fixed and the CPU and memory usage is drastically reduced.

Related: #594 #630 #654 #638 #472 #297 