### PR TITLE
Logger setup

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,12 +27,7 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
-    'no-console': [
-      'error',
-      {
-        allow: ['warn', 'error'],
-      },
-    ],
+    'no-console': ['error'],
     'prefer-destructuring': [
       'error',
       {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ endif
 For Vim 8 or Neovim using [YouCompleteMe](https://github.com/ycm-core/YouCompleteMe), add the following to `.vimrc`:
 
 ```vim
-let g:ycm_language_server = 
+let g:ycm_language_server =
             \ [
             \   {
             \       'name': 'bash',
@@ -160,7 +160,8 @@ Add the configuration to your `.emacs.d/init.el`
 
 ## Logging
 
-The minimum logging level for the server can be adjusted using the `BASH_IDE_LOG_LEVEL` environment variable. The options are `DEBUG|INFO|WARNING|ERROR`.
+The minimum logging level for the server can be adjusted using the `BASH_IDE_LOG_LEVEL` environment variable
+and through the general [workspace configuration](https://github.com/bash-lsp/bash-language-server/blob/main/server/src/config.ts).
 
 ## Development Guide
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bash language server that brings an IDE-like experience for bash scripts to most
 
 We strongly recommend that you install [shellcheck][shellcheck] to enable linting: https://github.com/koalaman/shellcheck#installing
 
-Documentation around configuration can be found in the [config.ts](https://github.com/bash-lsp/bash-language-server/blob/main/server/src/config.ts) file.
+Documentation around configuration variables can be found in the [config.ts](https://github.com/bash-lsp/bash-language-server/blob/main/server/src/config.ts) file.
 
 ## Features
 
@@ -24,6 +24,10 @@ To be implemented:
 
 ## Installation
 
+Usually you want to install a client for your editor (see the section below).
+
+But if you want to install the server binary:
+
 ```bash
 npm i -g bash-language-server
 ```
@@ -32,6 +36,12 @@ On Fedora based distros:
 
 ```bash
 dnf install -y nodejs-bash-language-server
+```
+
+To verify that everything is working:
+
+```bash
+bash-language-server --help
 ```
 
 If you encounter installation errors, ensure you have node version 14 or newer (`node --version`).
@@ -147,6 +157,10 @@ Add the configuration to your `.emacs.d/init.el`
   :hook
   (sh-mode . lsp))
 ```
+
+## Logging
+
+The minimum logging level for the server can be adjusted using the `BASH_IDE_LOG_LEVEL` environment variable. The options are `DEBUG|INFO|WARNING|ERROR`.
 
 ## Development Guide
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.3.0
+
+- Add centralized and configurable logger that can be controlled using the `BASH_IDE_LOG_LEVEL` environment variable and workspace configuration. https://github.com/bash-lsp/bash-language-server/pull/669
+
 ## 4.2.5
 
 - Fix a critical bug causing memory leaks and high CPU usage for workspaces with many files https://github.com/bash-lsp/bash-language-server/pull/661

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.2.5",
+  "version": "4.3.0",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -6,26 +6,30 @@ import {
   FIXTURE_URI,
   REPO_ROOT_FOLDER,
 } from '../../../testing/fixtures'
-import { getMockConnection } from '../../../testing/mocks'
 import Analyzer from '../analyser'
 import { getDefaultConfiguration } from '../config'
 import { initializeParser } from '../parser'
 import * as fsUtil from '../util/fs'
+import { Logger } from '../util/logger'
 
 let analyzer: Analyzer
 
 const CURRENT_URI = 'dummy-uri.sh'
-const mockConsole = getMockConnection().console
 
 // if you add a .sh file to testing/fixtures, update this value
 const FIXTURE_FILES_MATCHING_GLOB = 15
 
 const defaultConfig = getDefaultConfiguration()
 
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {
+  // noop
+})
+const loggerDebug = jest.spyOn(Logger.prototype, 'debug')
+const loggerWarn = jest.spyOn(Logger.prototype, 'warn')
+
 beforeAll(async () => {
   const parser = await initializeParser()
   analyzer = new Analyzer({
-    console: mockConsole,
     parser,
     workspaceFolder: FIXTURE_FOLDER,
   })
@@ -93,9 +97,7 @@ describe('findDeclarationLocations', () => {
     const { uri } = document
 
     const parser = await initializeParser()
-    const connection = getMockConnection()
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: REPO_ROOT_FOLDER,
     })
@@ -242,10 +244,8 @@ describe('getDeclarationsForUri', () => {
 describe('findAllSourcedUris', () => {
   it('returns references to sourced files', async () => {
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: pathToFileURL(REPO_ROOT_FOLDER).href,
     })
@@ -266,10 +266,8 @@ describe('findAllSourcedUris', () => {
 
   it('returns references to sourced files without file extension', async () => {
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: FIXTURE_FOLDER,
     })
@@ -344,10 +342,8 @@ describe('commandNameAtPoint', () => {
 describe('findDeclarationsMatchingWord', () => {
   it('returns a list of symbols across the workspace when includeAllWorkspaceSymbols is true', async () => {
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const analyzer = new Analyzer({
-      console: connection.console,
       parser,
       includeAllWorkspaceSymbols: true,
       workspaceFolder: FIXTURE_FOLDER,
@@ -456,10 +452,8 @@ describe('findDeclarationsMatchingWord', () => {
 
   it('returns a list of symbols accessible to the uri when includeAllWorkspaceSymbols is false', async () => {
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const analyzer = new Analyzer({
-      console: connection.console,
       parser,
       includeAllWorkspaceSymbols: false,
       workspaceFolder: FIXTURE_FOLDER,
@@ -510,10 +504,8 @@ describe('findDeclarationsMatchingWord', () => {
 
   it('returns symbols depending on the scope', async () => {
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const analyzer = new Analyzer({
-      console: connection.console,
       parser,
       includeAllWorkspaceSymbols: false,
       workspaceFolder: FIXTURE_FOLDER,
@@ -721,10 +713,7 @@ describe('initiateBackgroundAnalysis', () => {
 
     jest.spyOn(Date, 'now').mockImplementation(() => 0)
 
-    const connection = getMockConnection()
-
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: FIXTURE_FOLDER,
     })
@@ -733,13 +722,12 @@ describe('initiateBackgroundAnalysis', () => {
       globPattern: defaultConfig.globPattern,
     })
 
-    expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
-    expect(connection.console.warn).not.toHaveBeenCalled()
+    expect(loggerWarn).not.toHaveBeenCalled()
 
     // Intro, stats on glob, one file skipped due to shebang, and outro
     expect(filesParsed).toEqual(FIXTURE_FILES_MATCHING_GLOB)
 
-    expect(connection.console.log).toHaveBeenNthCalledWith(
+    expect(loggerDebug).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('BackgroundAnalysis: resolving glob'),
     )
@@ -752,10 +740,7 @@ describe('initiateBackgroundAnalysis', () => {
 
     const parser = await initializeParser()
 
-    const connection = getMockConnection()
-
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: FIXTURE_FOLDER,
     })
@@ -764,8 +749,7 @@ describe('initiateBackgroundAnalysis', () => {
       globPattern: defaultConfig.globPattern,
     })
 
-    expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
-    expect(connection.console.warn).toHaveBeenCalledWith(expect.stringContaining('BOOM'))
+    expect(loggerWarn).toHaveBeenCalledWith(expect.stringContaining('BOOM'))
     expect(filesParsed).toEqual(0)
   })
 
@@ -774,10 +758,7 @@ describe('initiateBackgroundAnalysis', () => {
 
     jest.spyOn(Date, 'now').mockImplementation(() => 0)
 
-    const connection = getMockConnection()
-
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: FIXTURE_FOLDER,
     })
@@ -786,8 +767,7 @@ describe('initiateBackgroundAnalysis', () => {
       globPattern: defaultConfig.globPattern,
     })
 
-    expect(connection.window.showWarningMessage).not.toHaveBeenCalled()
-    expect(connection.console.warn).not.toHaveBeenCalled()
+    expect(loggerWarn).not.toHaveBeenCalled()
 
     expect(filesParsed).toEqual(0)
   })
@@ -799,10 +779,8 @@ describe('getAllVariables', () => {
     const { uri } = document
 
     const parser = await initializeParser()
-    const connection = getMockConnection()
 
     const newAnalyzer = new Analyzer({
-      console: connection.console,
       parser,
       workspaceFolder: REPO_ROOT_FOLDER,
     })

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -24,7 +24,7 @@ const defaultConfig = getDefaultConfiguration()
 jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {
   // noop
 })
-const loggerDebug = jest.spyOn(Logger.prototype, 'debug')
+const loggerInfo = jest.spyOn(Logger.prototype, 'info')
 const loggerWarn = jest.spyOn(Logger.prototype, 'warn')
 
 beforeAll(async () => {
@@ -727,7 +727,7 @@ describe('initiateBackgroundAnalysis', () => {
     // Intro, stats on glob, one file skipped due to shebang, and outro
     expect(filesParsed).toEqual(FIXTURE_FILES_MATCHING_GLOB)
 
-    expect(loggerDebug).toHaveBeenNthCalledWith(
+    expect(loggerInfo).toHaveBeenNthCalledWith(
       1,
       expect.stringContaining('BackgroundAnalysis: resolving glob'),
     )

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -1,4 +1,5 @@
 import { ConfigSchema, getConfigFromEnvironmentVariables } from '../config'
+import { LOG_LEVEL_ENV_VAR } from '../util/logger'
 
 describe('ConfigSchema', () => {
   it('returns a default', () => {
@@ -97,6 +98,7 @@ describe('getConfigFromEnvironmentVariables', () => {
       EXPLAINSHELL_ENDPOINT: 'localhost:8080',
       GLOB_PATTERN: '*.*',
       BACKGROUND_ANALYSIS_MAX_FILES: '1',
+      [LOG_LEVEL_ENV_VAR]: 'error',
     }
     const { config } = getConfigFromEnvironmentVariables()
     expect(config).toMatchInlineSnapshot(`
@@ -106,7 +108,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "globPattern": "*.*",
         "highlightParsingErrors": false,
         "includeAllWorkspaceSymbols": false,
-        "logLevel": "info",
+        "logLevel": "error",
         "shellcheckArguments": Array [
           "-e",
           "SC2001",

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -9,6 +9,7 @@ describe('ConfigSchema', () => {
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "highlightParsingErrors": false,
         "includeAllWorkspaceSymbols": false,
+        "logLevel": "info",
         "shellcheckArguments": Array [],
         "shellcheckPath": "shellcheck",
       }
@@ -32,6 +33,7 @@ describe('ConfigSchema', () => {
         "globPattern": "**/*@(.sh)",
         "highlightParsingErrors": true,
         "includeAllWorkspaceSymbols": true,
+        "logLevel": "info",
         "shellcheckArguments": Array [
           "-e",
           "SC2001",
@@ -62,6 +64,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "highlightParsingErrors": false,
         "includeAllWorkspaceSymbols": false,
+        "logLevel": "info",
         "shellcheckArguments": Array [],
         "shellcheckPath": "shellcheck",
       }
@@ -80,6 +83,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "highlightParsingErrors": false,
         "includeAllWorkspaceSymbols": false,
+        "logLevel": "info",
         "shellcheckArguments": Array [],
         "shellcheckPath": "",
       }
@@ -102,6 +106,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "globPattern": "*.*",
         "highlightParsingErrors": false,
         "includeAllWorkspaceSymbols": false,
+        "logLevel": "info",
         "shellcheckArguments": Array [
           "-e",
           "SC2001",

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -14,11 +14,16 @@ import {
 import { getMockConnection } from '../../../testing/mocks'
 import LspServer from '../server'
 import { CompletionItemDataType } from '../types'
+import { Logger } from '../util/logger'
 
 // Skip ShellCheck throttle delay in test cases
 jest.spyOn(global, 'setTimeout').mockImplementation((fn) => {
   fn()
   return 0 as any
+})
+
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {
+  // noop
 })
 
 async function initializeServer(
@@ -480,6 +485,7 @@ describe('server', () => {
     )
 
     if (getOptionsResult.status !== 0) {
+      // eslint-disable-next-line no-console
       console.warn('Skipping onCompletion test as get-options.sh failed')
       return
     }

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -125,11 +125,11 @@ export default class Analyzer {
     }
 
     if (backgroundAnalysisMaxFiles <= 0) {
-      logger.debug(`BackgroundAnalysis: skipping as backgroundAnalysisMaxFiles was 0...`)
+      logger.info(`BackgroundAnalysis: skipping as backgroundAnalysisMaxFiles was 0...`)
       return { filesParsed: 0 }
     }
 
-    logger.debug(
+    logger.info(
       `BackgroundAnalysis: resolving glob "${globPattern}" inside "${rootPath}"...`,
     )
 
@@ -151,7 +151,7 @@ export default class Analyzer {
       return { filesParsed: 0 }
     }
 
-    logger.debug(
+    logger.info(
       `BackgroundAnalysis: Glob resolved with ${
         filePaths.length
       } files after ${getTimePassed()}`,
@@ -164,7 +164,7 @@ export default class Analyzer {
         const fileContent = await readFileAsync(filePath, 'utf8')
         const { shebang, shellDialect } = analyzeShebang(fileContent)
         if (shebang && !shellDialect) {
-          logger.debug(
+          logger.info(
             `BackgroundAnalysis: Skipping file ${uri} with shebang "${shebang}"`,
           )
           continue
@@ -180,7 +180,7 @@ export default class Analyzer {
       }
     }
 
-    logger.debug(`BackgroundAnalysis: Completed after ${getTimePassed()}.`)
+    logger.info(`BackgroundAnalysis: Completed after ${getTimePassed()}.`)
     return {
       filesParsed: filePaths.length,
     }
@@ -518,7 +518,7 @@ export default class Analyzer {
             uri,
           })
         } catch (err) {
-          logger.debug(`Error while analyzing sourced file ${uri}: ${err}`)
+          logger.warn(`Error while analyzing sourced file ${uri}: ${err}`)
           return false
         }
       }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { DEFAULT_LOG_LEVEL, LOG_LEVELS } from './util/logger'
+import { DEFAULT_LOG_LEVEL, LOG_LEVEL_ENV_VAR, LOG_LEVELS } from './util/logger'
 
 export const ConfigSchema = z.object({
   // Maximum number of files to analyze in the background. Set to 0 to disable background analysis.
@@ -54,6 +54,7 @@ export function getConfigFromEnvironmentVariables(): {
     globPattern: process.env.GLOB_PATTERN,
     highlightParsingErrors: toBoolean(process.env.HIGHLIGHT_PARSING_ERRORS),
     includeAllWorkspaceSymbols: toBoolean(process.env.INCLUDE_ALL_WORKSPACE_SYMBOLS),
+    logLevel: process.env[LOG_LEVEL_ENV_VAR],
     shellcheckArguments: process.env.SHELLCHECK_ARGUMENTS,
     shellcheckPath: process.env.SHELLCHECK_PATH,
   }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -2,47 +2,45 @@ import { z } from 'zod'
 
 import { DEFAULT_LOG_LEVEL, LOG_LEVELS } from './util/logger'
 
-export const ConfigSchema = z
-  .object({
-    // Maximum number of files to analyze in the background. Set to 0 to disable background analysis.
-    backgroundAnalysisMaxFiles: z.number().int().min(0).default(500),
+export const ConfigSchema = z.object({
+  // Maximum number of files to analyze in the background. Set to 0 to disable background analysis.
+  backgroundAnalysisMaxFiles: z.number().int().min(0).default(500),
 
-    // Glob pattern for finding and parsing shell script files in the workspace. Used by the background analysis features across files.
-    globPattern: z.string().trim().default('**/*@(.sh|.inc|.bash|.command)'),
+  // Glob pattern for finding and parsing shell script files in the workspace. Used by the background analysis features across files.
+  globPattern: z.string().trim().default('**/*@(.sh|.inc|.bash|.command)'),
 
-    // Configure explainshell server endpoint in order to get hover documentation on flags and options.
-    // And empty string will disable the feature.
-    explainshellEndpoint: z.string().trim().default(''),
+  // Configure explainshell server endpoint in order to get hover documentation on flags and options.
+  // And empty string will disable the feature.
+  explainshellEndpoint: z.string().trim().default(''),
 
-    // Log level for the server. To set the right log level from the start please also use the environment variable 'BASH_IDE_LOG_LEVEL'.
-    logLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
+  // Log level for the server. To set the right log level from the start please also use the environment variable 'BASH_IDE_LOG_LEVEL'.
+  logLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
 
-    // Controls if Treesitter parsing errors will be highlighted as problems.
-    highlightParsingErrors: z.boolean().default(false),
+  // Controls if Treesitter parsing errors will be highlighted as problems.
+  highlightParsingErrors: z.boolean().default(false),
 
-    // Controls how symbols (e.g. variables and functions) are included and used for completion and documentation.
-    // If false, then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh').
-    // If true, then all symbols from the workspace are included.
-    includeAllWorkspaceSymbols: z.boolean().default(false),
+  // Controls how symbols (e.g. variables and functions) are included and used for completion and documentation.
+  // If false, then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh').
+  // If true, then all symbols from the workspace are included.
+  includeAllWorkspaceSymbols: z.boolean().default(false),
 
-    // Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, --external-sources."
-    shellcheckArguments: z
-      .preprocess((arg) => {
-        let argsList: string[] = []
-        if (typeof arg === 'string') {
-          argsList = arg.split(' ')
-        } else if (Array.isArray(arg)) {
-          argsList = arg as string[]
-        }
+  // Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, --external-sources."
+  shellcheckArguments: z
+    .preprocess((arg) => {
+      let argsList: string[] = []
+      if (typeof arg === 'string') {
+        argsList = arg.split(' ')
+      } else if (Array.isArray(arg)) {
+        argsList = arg as string[]
+      }
 
-        return argsList.map((s) => s.trim()).filter((s) => s.length > 0)
-      }, z.array(z.string()))
-      .default([]),
+      return argsList.map((s) => s.trim()).filter((s) => s.length > 0)
+    }, z.array(z.string()))
+    .default([]),
 
-    // Controls the executable used for ShellCheck linting information. An empty string will disable linting.
-    shellcheckPath: z.string().trim().default('shellcheck'),
-  })
-  .strict()
+  // Controls the executable used for ShellCheck linting information. An empty string will disable linting.
+  shellcheckPath: z.string().trim().default('shellcheck'),
+})
 
 export type Config = z.infer<typeof ConfigSchema>
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
 
+import { DEFAULT_LOG_LEVEL, LOG_LEVELS } from './util/logger'
+
 export const ConfigSchema = z
   .object({
     // Maximum number of files to analyze in the background. Set to 0 to disable background analysis.
@@ -11,6 +13,9 @@ export const ConfigSchema = z
     // Configure explainshell server endpoint in order to get hover documentation on flags and options.
     // And empty string will disable the feature.
     explainshellEndpoint: z.string().trim().default(''),
+
+    // Log level for the server. To set the right log level from the start please also use the environment variable 'BASH_IDE_LOG_LEVEL'.
+    logLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
 
     // Controls if Treesitter parsing errors will be highlighted as problems.
     highlightParsingErrors: z.boolean().default(false),
@@ -42,7 +47,7 @@ export const ConfigSchema = z
 export type Config = z.infer<typeof ConfigSchema>
 
 export function getConfigFromEnvironmentVariables(): {
-  config: z.infer<typeof ConfigSchema>
+  config: Config
   environmentVariablesUsed: string[]
 } {
   const rawConfig = {
@@ -64,7 +69,7 @@ export function getConfigFromEnvironmentVariables(): {
   return { config, environmentVariablesUsed }
 }
 
-export function getDefaultConfiguration(): z.infer<typeof ConfigSchema> {
+export function getDefaultConfiguration(): Config {
   return ConfigSchema.parse({})
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,10 +1,9 @@
+// TODO: combine this with server/bin as this is only used for that. Rename to bin.ts
 'use strict'
 
 import * as LSP from 'vscode-languageserver/node'
 
 import BashServer from './server'
-
-const pkg = require('../package')
 
 export function listen() {
   // Create a connection for the server.
@@ -16,12 +15,8 @@ export function listen() {
 
   connection.onInitialize(
     async (params: LSP.InitializeParams): Promise<LSP.InitializeResult> => {
-      connection.console.log(`Initialized server v. ${pkg.version} for ${params.rootUri}`)
-
       const server = await BashServer.initialize(connection, params)
-
       server.register(connection)
-
       return {
         capabilities: server.capabilities(),
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -16,7 +16,7 @@ import * as ReservedWords from './reserved-words'
 import { Linter } from './shellcheck'
 import { BashCompletionItem, CompletionItemDataType } from './types'
 import { uniqueBasedOnHash } from './util/array'
-import { logger, setLogConnection } from './util/logger'
+import { logger, setLogConnection, setLogLevel } from './util/logger'
 import { getShellDocumentation } from './util/sh'
 
 const PARAMETER_EXPANSION_PREFIXES = new Set(['$', '${'])
@@ -59,7 +59,7 @@ export default class BashServer {
     this.linter = linter
     this.workspaceFolder = workspaceFolder
     this.config = {} as any // NOTE: configured in updateConfiguration
-    this.updateConfiguration(config.getDefaultConfiguration())
+    this.updateConfiguration(config.getDefaultConfiguration(), true)
   }
 
   /**
@@ -242,7 +242,7 @@ export default class BashServer {
     return Promise.resolve({ filesParsed: 0 })
   }
 
-  private updateConfiguration(configObject: any): boolean {
+  private updateConfiguration(configObject: any, isDefaultConfig = false): boolean {
     if (typeof configObject === 'object' && configObject !== null) {
       try {
         const newConfig = config.ConfigSchema.parse(configObject)
@@ -265,6 +265,12 @@ export default class BashServer {
           this.analyzer.setIncludeAllWorkspaceSymbols(
             this.config.includeAllWorkspaceSymbols,
           )
+
+          if (!isDefaultConfig) {
+            // We skip setting the log level as the default configuration should
+            // not override the environment defined log level.
+            setLogLevel(this.config.logLevel)
+          }
 
           return true
         }

--- a/server/src/util/__tests__/logger.test.ts
+++ b/server/src/util/__tests__/logger.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable no-console */
+import * as LSP from 'vscode-languageserver'
+
+import { getMockConnection } from '../../../../testing/mocks'
+import {
+  getLogLevelFromEnvironment,
+  LOG_LEVEL_ENV_VAR,
+  Logger,
+  setLogConnection,
+  setLogLevel,
+} from '../logger'
+
+const mockConnection = getMockConnection()
+beforeAll(() => {
+  setLogConnection(mockConnection)
+  setLogLevel(LSP.MessageType.Info)
+  jest.useFakeTimers().setSystemTime(1522431328992)
+})
+
+jest.spyOn(console, 'warn').mockImplementation(() => {
+  // noop
+})
+
+describe('Logger', () => {
+  it('logs simple message', () => {
+    const logger = new Logger()
+    logger.info('a test')
+    logger.warn('another test')
+    expect(mockConnection.sendNotification).toHaveBeenCalledTimes(2)
+    expect(mockConnection.sendNotification).toHaveBeenNthCalledWith(
+      1,
+      LSP.LogMessageNotification.type,
+      {
+        type: LSP.MessageType.Info,
+        message: '17:35:28.992 INFO a test',
+      },
+    )
+    expect(mockConnection.sendNotification).toHaveBeenNthCalledWith(
+      2,
+      LSP.LogMessageNotification.type,
+      {
+        type: LSP.MessageType.Warning,
+        message: '17:35:28.992 WARNING ⛔️ another test',
+      },
+    )
+  })
+
+  it('allows parsing arguments', () => {
+    const logger = new Logger({ prefix: 'myFunc' })
+    logger.info('foo', 'bar', 1)
+    expect(mockConnection.sendNotification).toHaveBeenCalledTimes(1)
+    expect(mockConnection.sendNotification.mock.calls[0][1]).toEqual({
+      type: LSP.MessageType.Info,
+      message: '17:35:28.992 INFO myFunc - foo bar 1',
+    })
+  })
+
+  it('allows parsing arguments with objects', () => {
+    const logger = new Logger({ prefix: 'myFunc' })
+    logger.error('foo', { bar: 1 })
+    expect(mockConnection.sendNotification).toHaveBeenCalledTimes(1)
+    expect(mockConnection.sendNotification.mock.calls[0][1]).toEqual({
+      type: LSP.MessageType.Error,
+      message: '17:35:28.992 ERROR ⛔️ myFunc - foo {\n' + '  "bar": 1\n' + '}',
+    })
+  })
+
+  it('handles Error', () => {
+    const logger = new Logger()
+    logger.error('msg', new Error('boom'))
+    expect(mockConnection.sendNotification).toHaveBeenCalledTimes(1)
+    expect(mockConnection.sendNotification.mock.calls[0][1]).toEqual({
+      type: LSP.MessageType.Error,
+      message: expect.stringContaining('17:35:28.992 ERROR ⛔️ msg Error: boom'),
+    })
+  })
+})
+
+describe('getLogLevelFromEnvironment', () => {
+  it('returns default log level if no environment variable is set', () => {
+    expect(getLogLevelFromEnvironment()).toEqual(LSP.MessageType.Info)
+  })
+
+  it('returns default log level if environment variable is set to an invalid value', () => {
+    process.env[LOG_LEVEL_ENV_VAR] = 'invalid'
+    expect(getLogLevelFromEnvironment()).toEqual(LSP.MessageType.Info)
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      `Invalid BASH_IDE_LOG_LEVEL "invalid", expected one of: DEBUG, INFO, WARNING, ERROR`,
+    )
+  })
+
+  it('returns log level from environment variable', () => {
+    process.env[LOG_LEVEL_ENV_VAR] = 'DEBUG'
+    expect(getLogLevelFromEnvironment()).toEqual(LSP.MessageType.Log)
+  })
+})

--- a/server/src/util/__tests__/logger.test.ts
+++ b/server/src/util/__tests__/logger.test.ts
@@ -13,7 +13,7 @@ import {
 const mockConnection = getMockConnection()
 beforeAll(() => {
   setLogConnection(mockConnection)
-  setLogLevel(LSP.MessageType.Info)
+  setLogLevel('info')
   jest.useFakeTimers().setSystemTime(1522431328992)
 })
 
@@ -87,12 +87,12 @@ describe('getLogLevelFromEnvironment', () => {
 
     expect(console.warn).toHaveBeenCalledTimes(1)
     expect(console.warn).toHaveBeenCalledWith(
-      `Invalid BASH_IDE_LOG_LEVEL "invalid", expected one of: DEBUG, INFO, WARNING, ERROR`,
+      `Invalid BASH_IDE_LOG_LEVEL "invalid", expected one of: debug, info, warning, error`,
     )
   })
 
   it('returns log level from environment variable', () => {
-    process.env[LOG_LEVEL_ENV_VAR] = 'DEBUG'
+    process.env[LOG_LEVEL_ENV_VAR] = 'debug'
     expect(getLogLevelFromEnvironment()).toEqual(LSP.MessageType.Log)
   })
 })

--- a/server/src/util/logger.ts
+++ b/server/src/util/logger.ts
@@ -1,0 +1,117 @@
+import * as LSP from 'vscode-languageserver'
+
+export const LOG_LEVEL_ENV_VAR = 'BASH_IDE_LOG_LEVEL'
+
+// Singleton madness to allow for logging from anywhere in the codebase
+let _connection: LSP.Connection | null = null
+let _logLevel: LSP.MessageType = getLogLevelFromEnvironment()
+
+/**
+ * Set the log connection. Should be done at startup.
+ */
+export function setLogConnection(connection: LSP.Connection) {
+  _connection = connection
+}
+
+/**
+ * Set the minimum log level.
+ */
+export function setLogLevel(logLevel: LSP.MessageType) {
+  _logLevel = logLevel
+}
+
+export class Logger {
+  private prefix: string
+
+  constructor({ prefix = '' }: { prefix?: string } = {}) {
+    this.prefix = prefix
+  }
+
+  static MESSAGE_TYPE_TO_LOG_LEVEL_MSG: Record<LSP.MessageType, string> = {
+    [LSP.MessageType.Error]: 'ERROR ⛔️',
+    [LSP.MessageType.Warning]: 'WARNING ⛔️',
+    [LSP.MessageType.Info]: 'INFO',
+    [LSP.MessageType.Log]: 'DEBUG',
+  }
+
+  public log(severity: LSP.MessageType, messageObjects: any[]) {
+    if (_logLevel < severity) {
+      return
+    }
+
+    if (!_connection) {
+      // eslint-disable-next-line no-console
+      console.warn(`The logger's LSP Connection is not set. Dropping messages`)
+      return
+    }
+
+    const formattedMessage = messageObjects
+      .map((p) => {
+        if (p instanceof Error) {
+          return p.stack || p.message
+        }
+
+        if (typeof p === 'object') {
+          return JSON.stringify(p, null, 2)
+        }
+
+        return p
+      })
+      .join(' ')
+
+    const level = Logger.MESSAGE_TYPE_TO_LOG_LEVEL_MSG[severity]
+    const prefix = this.prefix ? `${this.prefix} - ` : ''
+    const time = new Date().toISOString().substring(11, 23)
+    const message = `${time} ${level} ${prefix}${formattedMessage}`
+
+    _connection.sendNotification(LSP.LogMessageNotification.type, {
+      type: severity,
+      message,
+    })
+  }
+
+  public debug(message: string, ...additionalArgs: any[]) {
+    this.log(LSP.MessageType.Log, [message, ...additionalArgs])
+  }
+  public info(message: string, ...additionalArgs: any[]) {
+    this.log(LSP.MessageType.Info, [message, ...additionalArgs])
+  }
+  public warn(message: string, ...additionalArgs: any[]) {
+    this.log(LSP.MessageType.Warning, [message, ...additionalArgs])
+  }
+  public error(message: string, ...additionalArgs: any[]) {
+    this.log(LSP.MessageType.Error, [message, ...additionalArgs])
+  }
+}
+
+export const logger = new Logger()
+
+/**
+ * Get the log level from the environment.
+ * Note that this is not part of the server/config.ts as this needs to be provided when
+ * the server starts.
+ */
+export function getLogLevelFromEnvironment(): LSP.MessageType {
+  const ENV_LOG_LEVELS_TO_MESSAGE_TYPES: Record<string, LSP.MessageType | undefined> = {
+    DEBUG: LSP.MessageType.Log,
+    INFO: LSP.MessageType.Info,
+    WARNING: LSP.MessageType.Warning,
+    ERROR: LSP.MessageType.Error,
+  }
+
+  const logLevelFromEnvironment = process.env[LOG_LEVEL_ENV_VAR]
+  if (logLevelFromEnvironment) {
+    const logLevel = ENV_LOG_LEVELS_TO_MESSAGE_TYPES[logLevelFromEnvironment]
+    if (logLevel) {
+      return logLevel
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Invalid ${LOG_LEVEL_ENV_VAR} "${logLevelFromEnvironment}", expected one of: ${Object.keys(
+        ENV_LOG_LEVELS_TO_MESSAGE_TYPES,
+      ).join(', ')}`,
+    )
+  }
+
+  return LSP.MessageType.Info
+}

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -1,5 +1,6 @@
 import * as ChildProcess from 'child_process'
 
+import { logger } from './logger'
 import { isWindows } from './platform'
 
 /**
@@ -91,7 +92,7 @@ export async function getShellDocumentationWithoutCache({
       }
     } catch (error) {
       // Ignoring if command fails and store failure in cache
-      console.error(`getShellDocumentation failed for "${word}"`, { error })
+      logger.error(`getShellDocumentation failed for "${word}"`, error)
     }
   }
 
@@ -109,9 +110,7 @@ export function formatManOutput(manOutput: string): string {
   const formattedManOutput = manOutput.slice(indexNameBlock, indexBeforeFooter)
 
   if (!formattedManOutput) {
-    console.error(`formatManOutput failed`, {
-      manOutput,
-    })
+    logger.error(`formatManOutput failed`, { manOutput })
     return manOutput
   }
 

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -16,4 +16,4 @@ echo "$"
 
 source ./scripts/tag-release.inc
 
-tagRelease '1.0.0' # FIXME: the "defined on" looks wierd
+tagRelease '1.0.0'

--- a/vscode-client/__tests__/config.test.ts
+++ b/vscode-client/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 const packageJson = require('../package.json')
 import { getDefaultConfiguration } from '../../server/src/config'
+import { LOG_LEVELS } from '../../server/src/util/logger'
 
 const defaultConfig = getDefaultConfiguration()
 
@@ -16,7 +17,14 @@ describe('config', () => {
     const configKeys = Object.keys(configProperties)
       .map((key) => key.replace(/^bashIde\./, ''))
       .sort()
+
     const defaultConfigKeys = Object.keys(defaultConfig).sort()
     expect(configKeys).toEqual(defaultConfigKeys)
+  })
+
+  it('matches the server log levels', () => {
+    const configLogLevels = configProperties['bashIde.logLevel'].enum?.sort()
+    expect(configLogLevels).toEqual(LOG_LEVELS.slice().sort())
+    expect(LOG_LEVELS).toContain(configProperties['bashIde.logLevel'].default)
   })
 })

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -57,6 +57,17 @@
           "default": false,
           "description": "Controls how symbols (e.g. variables and functions) are included and used for completion and documentation. If false (default and recommended), then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh'). If true, then all symbols from the workspace are included."
         },
+        "bashIde.logLevel": {
+          "type": "string",
+          "default": "info",
+          "enum": [
+            "debug",
+            "info",
+            "warning",
+            "error"
+          ],
+          "description": "Controls the log level of the language server."
+        },
         "bashIde.shellcheckPath": {
           "type": "string",
           "default": "shellcheck",

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -11,9 +11,13 @@ import {
 
 let client: LanguageClient
 
+export const CONFIGURATION_SECTION = 'bashIde' // matching the package.json configuration section
+
 export async function activate(context: ExtensionContext) {
+  const config = workspace.getConfiguration(CONFIGURATION_SECTION)
   const env: any = {
     ...process.env,
+    BASH_IDE_LOG_LEVEL: config.get('logLevel', ''),
   }
 
   const serverExecutable = {
@@ -52,7 +56,7 @@ export async function activate(context: ExtensionContext) {
       },
     ],
     synchronize: {
-      configurationSection: 'bashIde',
+      configurationSection: CONFIGURATION_SECTION,
       // Notify the server about file changes to '.clientrc files contain in the workspace
       fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },

--- a/vscode-client/src/server.ts
+++ b/vscode-client/src/server.ts
@@ -9,13 +9,8 @@ import {
 const connection = createConnection(ProposedFeatures.all)
 
 connection.onInitialize(async (params: InitializeParams): Promise<InitializeResult> => {
-  connection.console.info('BashLanguageServer initializing...')
-
   const server = await BashLanguageServer.initialize(connection, params)
   server.register(connection)
-
-  connection.console.info('BashLanguageServer initialized')
-
   return {
     capabilities: server.capabilities(),
   }


### PR DESCRIPTION
This PR introduces a better logging setup:
- centralize logging
- make the logging output better including timestamp and log severity
- make minimum log level configurable through environment variable `BASH_IDE_LOG_LEVEL` and through workspace configuration

Note that the environment variable should be used in combination with workspace configuration in order to ensure that the server starts with the right level (i.e. before workspace configuration is available).

### Before
<img width="1105" alt="Screenshot 2023-01-09 at 14 04 04" src="https://user-images.githubusercontent.com/1260305/211315160-50e59888-c73f-4fd5-88de-e5f3a3d99fa0.png">

### After
<img width="1131" alt="Screenshot 2023-01-09 at 14 07 21" src="https://user-images.githubusercontent.com/1260305/211315144-c530620f-80cc-40f7-96fd-df7a095a40d5.png">

(slightly cluttered as vscode mixes up trace logs)

Related to https://github.com/bash-lsp/bash-language-server/issues/273