### PR TITLE
Improving sourcing analysis and diagnostics

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Bash Language Server
 
+## 4.4.0
+
+- Improve source command parser and include diagnostics when parser fails https://github.com/bash-lsp/bash-language-server/pull/673
+- Fix `onHover` bug where sourced symbols on the same line as a reference would hide documentation https://github.com/bash-lsp/bash-language-server/pull/673
+
+## 4.3.2
+
+- Improved CLI output https://github.com/bash-lsp/bash-language-server/pull/672
+
 ## 4.3.0
 
 - Add centralized and configurable logger that can be controlled using the `BASH_IDE_LOG_LEVEL` environment variable and workspace configuration. https://github.com/bash-lsp/bash-language-server/pull/669

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.3.2",
+  "version": "4.4.0",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -1,43 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`analyze returns a list of errors for a file with a missing node 1`] = `
-Array [
-  Object {
-    "message": "Syntax error: expected \\"fi\\" somewhere in the file",
-    "range": Object {
-      "end": Object {
-        "character": 0,
-        "line": 12,
-      },
-      "start": Object {
-        "character": 0,
-        "line": 12,
-      },
-    },
-    "severity": 2,
-  },
-]
-`;
-
-exports[`analyze returns a list of errors for a file with parsing errors 1`] = `
-Array [
-  Object {
-    "message": "Failed to parse",
-    "range": Object {
-      "end": Object {
-        "character": 1,
-        "line": 9,
-      },
-      "start": Object {
-        "character": 0,
-        "line": 2,
-      },
-    },
-    "severity": 1,
-  },
-]
-`;
-
 exports[`findReferences returns a list of locations if parameter is found 1`] = `
 Array [
   Object {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -208,6 +208,23 @@ describe('server', () => {
           },
           "name": "BOLD",
         },
+        Object {
+          "kind": 12,
+          "location": Object {
+            "range": Object {
+              "end": Object {
+                "character": 1,
+                "line": 22,
+              },
+              "start": Object {
+                "character": 0,
+                "line": 20,
+              },
+            },
+            "uri": "file://${FIXTURE_FOLDER}sourcing.sh",
+          },
+          "name": "loadlib",
+        },
       ]
     `)
   })

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -78,7 +78,6 @@ export default class Analyzer {
       document,
       globalDeclarations,
       sourcedUris: sourcing.getSourcedUris({
-        fileContent,
         fileUri: uri,
         rootPath: this.workspaceFolder,
         tree,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -61,7 +61,8 @@ export function getConfigFromEnvironmentVariables(): {
 
   const environmentVariablesUsed = Object.entries(rawConfig)
     .map(([key, value]) => (typeof value !== 'undefined' ? key : null))
-    .filter((key) => key !== null) as string[]
+    .filter((key): key is string => key !== null)
+    .filter((key) => key !== 'logLevel') // logLevel is a special case that we ignore
 
   const config = ConfigSchema.parse(rawConfig)
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -364,6 +364,9 @@ export default class BashServer {
     symbol: LSP.SymbolInformation
     currentUri: string
   }): LSP.MarkupContent {
+    logger.debug(
+      `getDocumentationForSymbol: symbol=${symbol.name} uri=${symbol.location.uri}`,
+    )
     const symbolUri = symbol.location.uri
     const symbolStartLine = symbol.location.range.start.line
 
@@ -665,6 +668,9 @@ export default class BashServer {
       Builtins.isBuiltin(word) ||
       (this.executables.isExecutableOnPATH(word) && symbolsMatchingWord.length == 0)
     ) {
+      logger.debug(
+        `onHover: getting shell documentation for reserved word or builtin or executable`,
+      )
       const shellDocumentation = await getShellDocumentation({ word })
       if (shellDocumentation) {
         return { contents: getMarkdownContent(shellDocumentation, 'man') }
@@ -675,7 +681,11 @@ export default class BashServer {
         currentUri,
       })
         // do not return hover referencing for the current line
-        .filter((symbol) => symbol.location.range.start.line !== params.position.line)
+        .filter(
+          (symbol) =>
+            symbol.location.uri !== currentUri ||
+            symbol.location.range.start.line !== params.position.line,
+        )
         .map((symbol: LSP.SymbolInformation) =>
           this.getDocumentationForSymbol({ currentUri, symbol }),
         )

--- a/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
+++ b/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
@@ -1,0 +1,146 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getSourcedUris returns a set of sourced files 2`] = `
+Array [
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 28,
+        "line": 1,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 1,
+      },
+    },
+    "uri": "file:///Users/bash/file-in-path.sh",
+  },
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 31,
+        "line": 3,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 3,
+      },
+    },
+    "uri": "file:///bin/extension.inc",
+  },
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 22,
+        "line": 5,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 5,
+      },
+    },
+    "uri": "file:///Users/bash/x",
+  },
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 36,
+        "line": 7,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 7,
+      },
+    },
+    "uri": "file:///Users/scripts/release-client.sh",
+  },
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 23,
+        "line": 9,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 9,
+      },
+    },
+    "uri": "file:///Users/bash-user/myscript",
+  },
+  Object {
+    "error": "expansion not supported",
+    "range": Object {
+      "end": Object {
+        "character": 23,
+        "line": 13,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 13,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": "expansion not supported",
+    "range": Object {
+      "end": Object {
+        "character": 66,
+        "line": 16,
+      },
+      "start": Object {
+        "character": 49,
+        "line": 16,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": "expansion not supported",
+    "range": Object {
+      "end": Object {
+        "character": 66,
+        "line": 18,
+      },
+      "start": Object {
+        "character": 6,
+        "line": 18,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": null,
+    "range": Object {
+      "end": Object {
+        "character": 30,
+        "line": 25,
+      },
+      "start": Object {
+        "character": 8,
+        "line": 25,
+      },
+    },
+    "uri": "file:///Users/bash/issue206.sh",
+  },
+  Object {
+    "error": "expansion not supported",
+    "range": Object {
+      "end": Object {
+        "character": 22,
+        "line": 43,
+      },
+      "start": Object {
+        "character": 8,
+        "line": 43,
+      },
+    },
+    "uri": null,
+  },
+]
+`;

--- a/server/src/util/__tests__/sourcing.test.ts
+++ b/server/src/util/__tests__/sourcing.test.ts
@@ -22,7 +22,6 @@ describe('getSourcedUris', () => {
   it('returns an empty set if no files were sourced', () => {
     const fileContent = ''
     const result = getSourcedUris({
-      fileContent,
       fileUri,
       rootPath: null,
       tree: parser.parse(fileContent),
@@ -44,17 +43,19 @@ describe('getSourcedUris', () => {
 
       # source ...
 
-      source "./issue206.sh" # quoted file in fixtures folder
-
       source "$LIBPATH" # dynamic imports not supported
 
       # conditional is currently not supported
       if [[ -z $__COMPLETION_LIB_LOADED ]]; then source "$LIBPATH" ; fi
 
+      . "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+
       show ()
       {
         about 'Shows SVN proxy settings'
         group 'proxy'
+
+        source "./issue206.sh" # quoted file in fixtures folder
 
         echo "SVN Proxy Settings"
         echo "=================="
@@ -74,7 +75,6 @@ describe('getSourcedUris', () => {
     `
 
     const result = getSourcedUris({
-      fileContent,
       fileUri,
       rootPath: null,
       tree: parser.parse(fileContent),

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -77,7 +77,7 @@ export function getAllDeclarationsInTree({
 }): LSP.SymbolInformation[] {
   const symbols: LSP.SymbolInformation[] = []
 
-  TreeSitterUtil.forEach(tree.rootNode, (node: Parser.SyntaxNode) => {
+  TreeSitterUtil.forEach(tree.rootNode, (node) => {
     if (TreeSitterUtil.isDefinition(node)) {
       const symbol = nodeToSymbolInformation({ node, uri })
 
@@ -189,7 +189,7 @@ function getAllGlobalVariableDeclarations({
 }) {
   const declarations: Declarations = {}
 
-  TreeSitterUtil.forEach(rootNode, (node: Parser.SyntaxNode) => {
+  TreeSitterUtil.forEach(rootNode, (node) => {
     if (
       node.type === 'variable_assignment' &&
       // exclude local variables

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -46,6 +46,8 @@ export function getGlobalDeclarations({
           TreeSitterUtil.range(node),
           'Failed to parse',
           LSP.DiagnosticSeverity.Error,
+          undefined,
+          'bash-language-server',
         ),
       )
       return

--- a/server/src/util/lsp.ts
+++ b/server/src/util/lsp.ts
@@ -1,0 +1,13 @@
+import * as LSP from 'vscode-languageserver/node'
+
+/**
+ * Determine if a position is included in a range.
+ */
+export function isPositionIncludedInRange(position: LSP.Position, range: LSP.Range) {
+  return (
+    range.start.line <= position.line &&
+    range.end.line >= position.line &&
+    range.start.character <= position.character &&
+    range.end.character >= position.character
+  )
+}

--- a/server/src/util/sourcing.ts
+++ b/server/src/util/sourcing.ts
@@ -68,6 +68,12 @@ function getSourcedPathInfoFromNode({
         }
       }
 
+      if (argumentNode.type === 'simple_expansion') {
+        return {
+          parseError: 'expansion not supported',
+        }
+      }
+
       if (argumentNode.type === 'string') {
         if (argumentNode.namedChildren.length === 0) {
           return {

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -17,3 +17,9 @@ echo "$"
 source ./scripts/tag-release.inc
 
 tagRelease '1.0.0'
+
+loadlib () {
+  source "$1.sh"
+}
+
+loadlib "issue206"


### PR DESCRIPTION
Resolves https://github.com/bash-lsp/bash-language-server/issues/658

This PR improves the sourcing analysis by using the AST instead of the crude regular expression. This means source commands nested in function are now found + we can return proper diagnostics when source commands are not resolved or supported. More context can be found in https://github.com/bash-lsp/bash-language-server/issues/658

The added diagnostics should hopefully clarify to the user why jump to definition or similar features isn't currently working.

### Example
<img width="713" alt="Screenshot 2023-01-10 at 22 07 28" src="https://user-images.githubusercontent.com/1260305/211662729-019ba907-2b7e-4b9c-a23b-eaf0d56589a1.png">


 