### PR TITLE
Simplify source error case handling

### DIFF
--- a/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
+++ b/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
@@ -20,7 +20,7 @@ Array [
     "error": null,
     "range": Object {
       "end": Object {
-        "character": 31,
+        "character": 33,
         "line": 3,
       },
       "start": Object {
@@ -73,7 +73,7 @@ Array [
     "uri": "file:///Users/bash-user/myscript",
   },
   Object {
-    "error": "expansion not supported",
+    "error": "non-constant source not supported",
     "range": Object {
       "end": Object {
         "character": 23,
@@ -87,7 +87,7 @@ Array [
     "uri": null,
   },
   Object {
-    "error": "expansion not supported",
+    "error": "non-constant source not supported",
     "range": Object {
       "end": Object {
         "character": 66,
@@ -101,7 +101,7 @@ Array [
     "uri": null,
   },
   Object {
-    "error": "expansion not supported",
+    "error": "non-constant source not supported",
     "range": Object {
       "end": Object {
         "character": 66,
@@ -129,15 +129,57 @@ Array [
     "uri": "file:///Users/bash/issue206.sh",
   },
   Object {
-    "error": "expansion not supported",
+    "error": "non-constant source not supported",
     "range": Object {
       "end": Object {
         "character": 22,
-        "line": 43,
+        "line": 47,
       },
       "start": Object {
         "character": 8,
-        "line": 43,
+        "line": 47,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": "non-constant source not supported",
+    "range": Object {
+      "end": Object {
+        "character": 39,
+        "line": 59,
+      },
+      "start": Object {
+        "character": 8,
+        "line": 59,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": "non-constant source not supported",
+    "range": Object {
+      "end": Object {
+        "character": 42,
+        "line": 62,
+      },
+      "start": Object {
+        "character": 8,
+        "line": 62,
+      },
+    },
+    "uri": null,
+  },
+  Object {
+    "error": "non-constant source not supported",
+    "range": Object {
+      "end": Object {
+        "character": 67,
+        "line": 89,
+      },
+      "start": Object {
+        "character": 10,
+        "line": 89,
       },
     },
     "uri": null,

--- a/server/src/util/sourcing.ts
+++ b/server/src/util/sourcing.ts
@@ -68,35 +68,18 @@ function getSourcedPathInfoFromNode({
         }
       }
 
-      if (argumentNode.type === 'simple_expansion') {
-        return {
-          parseError: 'expansion not supported',
-        }
-      }
-
-      if (argumentNode.type === 'string') {
+      if (argumentNode.type === 'string' || argumentNode.type === 'raw_string') {
         if (argumentNode.namedChildren.length === 0) {
           return {
             sourcedPath: argumentNode.text.slice(1, -1),
           }
-        } else if (
-          argumentNode.namedChildren.every((n) => n.type === 'simple_expansion')
-        ) {
-          return {
-            parseError: 'expansion not supported',
-          }
-        } else {
-          logger.warn(
-            'Sourcing: unhandled argumentNode=string case',
-            argumentNode.namedChildren.map((c) => ({ type: c.type, text: c.text })),
-          )
         }
-      } else {
-        logger.warn(`Sourcing: unhandled argumentNode=${argumentNode.type} case`)
       }
 
+      // TODO: we could try to parse any ShellCheck "source "directive
+      // # shellcheck source=src/examples/config.sh
       return {
-        parseError: `unhandled case node type "${argumentNode.type}"`,
+        parseError: `non-constant source not supported`,
       }
     }
   }

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -57,13 +57,12 @@ export async function activate(context: ExtensionContext) {
     ],
     synchronize: {
       configurationSection: CONFIGURATION_SECTION,
-      // Notify the server about file changes to '.clientrc files contain in the workspace
-      fileEvents: workspace.createFileSystemWatcher('**/.clientrc'),
     },
   }
 
   const client = new LanguageClient('Bash IDE', 'Bash IDE', serverOptions, clientOptions)
   client.registerProposedFeatures()
+
   try {
     await client.start()
   } catch (error) {


### PR DESCRIPTION
After testing this out on 50000 bash files I'm pretty confident that the source parsing and error reporting should be fine.