### PR TITLE
Fix onHover and goto definition in case of syntax issues

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Bash Language Server
 
+## 4.5.3
+
+- Fix issue where some features would work as expected in case of a syntax issue https://github.com/bash-lsp/bash-language-server/pull/691
+
 ## 4.5.2
 
-- fixed `onReferences` to respect the `context.includeDeclaration` flag
-- removed unnecessary dependency `urijs`
+- Fixed `onReferences` to respect the `context.includeDeclaration` flag https://github.com/bash-lsp/bash-language-server/pull/688
+- Removed unnecessary dependency `urijs` https://github.com/bash-lsp/bash-language-server/pull/688
 
 ## 4.5.1
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -18,7 +18,7 @@ let analyzer: Analyzer
 const CURRENT_URI = 'dummy-uri.sh'
 
 // if you add a .sh file to testing/fixtures, update this value
-const FIXTURE_FILES_MATCHING_GLOB = 15
+const FIXTURE_FILES_MATCHING_GLOB = 16
 
 const defaultConfig = getDefaultConfiguration()
 
@@ -783,6 +783,7 @@ describe('initiateBackgroundAnalysis', () => {
     expect(loggerWarn).toHaveBeenCalled()
     expect(loggerWarn.mock.calls).toEqual([
       [expect.stringContaining('missing-node.sh: syntax error')],
+      [expect.stringContaining('missing-node2.sh: syntax error')],
       [expect.stringContaining('not-a-shell-script.sh: syntax error')],
       [expect.stringContaining('parse-problems.sh: syntax error')],
     ])

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -46,12 +46,30 @@ describe('analyze', () => {
     expect(loggerWarn).not.toHaveBeenCalled()
   })
 
-  it('parses files with a missing node', () => {
+  it('parses files with a missing nodes and return relevant diagnostics', () => {
     const diagnostics = analyzer.analyze({
       uri: CURRENT_URI,
       document: FIXTURE_DOCUMENT.MISSING_NODE,
     })
-    expect(diagnostics).toEqual([])
+    expect(diagnostics).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "message": "Syntax error: \\"fi\\" missing",
+          "range": Object {
+            "end": Object {
+              "character": 0,
+              "line": 12,
+            },
+            "start": Object {
+              "character": 0,
+              "line": 12,
+            },
+          },
+          "severity": 2,
+          "source": "bash-language-server",
+        },
+      ]
+    `)
     expect(loggerWarn).toHaveBeenCalledWith(
       'Error while parsing dummy-uri.sh: syntax error',
     )

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -1046,8 +1046,22 @@ describe('server', () => {
         line: 2,
         character: 3,
       })
-      expect(result2).toBeDefined()
-      expect((result2 as any)?.contents.value).toBeUndefined()
+      expect(result2).toEqual(null)
+    })
+
+    it('responds with documentation even if parsing fails', async () => {
+      const result = await getHoverResult(FIXTURE_URI.MISSING_NODE2, {
+        // sleep
+        line: 12,
+        character: 4,
+      })
+
+      expect(result).toEqual({
+        contents: {
+          kind: 'markdown',
+          value: expect.stringContaining('suspends execution'),
+        },
+      })
     })
 
     it.skip('returns documentation from explainshell', async () => {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -1059,7 +1059,7 @@ describe('server', () => {
       expect(result).toEqual({
         contents: {
           kind: 'markdown',
-          value: expect.stringContaining('suspends execution'),
+          value: expect.stringContaining('sleep'),
         },
       })
     })

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -116,7 +116,11 @@ export default class Analyzer {
       logger.warn(`Error while parsing ${uri}: syntax error`)
     }
 
-    return diagnostics
+    const missingNodesDiagnostics = TreeSitterUtil.getDiagnosticsForMissingNodes(
+      tree.rootNode,
+    )
+
+    return diagnostics.concat(missingNodesDiagnostics)
   }
 
   /**

--- a/server/src/util/declarations.ts
+++ b/server/src/util/declarations.ts
@@ -154,20 +154,20 @@ export function getLocalDeclarations({
       node.type === 'program'
         ? node
         : TreeSitterUtil.findParent(node, (p) => p.type === 'program')
-    if (!rootNode) {
-      throw new Error('did not find root node')
-    }
 
-    Object.entries(
-      getAllGlobalVariableDeclarations({
-        rootNode,
-        uri,
-      }),
-    ).map(([name, symbols]) => {
-      if (!declarations[name]) {
-        declarations[name] = symbols
-      }
-    })
+    if (rootNode) {
+      // In case of parsing errors, the root node might not be found
+      Object.entries(
+        getAllGlobalVariableDeclarations({
+          rootNode,
+          uri,
+        }),
+      ).map(([name, symbols]) => {
+        if (!declarations[name]) {
+          declarations[name] = symbols
+        }
+      })
+    }
   }
 
   return declarations

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -1,4 +1,4 @@
-import { Range } from 'vscode-languageserver/node'
+import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver/node'
 import { SyntaxNode } from 'web-tree-sitter'
 
 /**
@@ -55,4 +55,25 @@ export function findParent(
     node = node.parent
   }
   return null
+}
+
+export function getDiagnosticsForMissingNodes(node: SyntaxNode) {
+  const diagnostics: Diagnostic[] = []
+
+  forEach(node, (node) => {
+    if (node.isMissing()) {
+      diagnostics.push(
+        Diagnostic.create(
+          range(node),
+          `Syntax error: "${node.type}" missing`,
+          DiagnosticSeverity.Warning,
+          undefined,
+          'bash-language-server',
+        ),
+      )
+    }
+    return node.hasError()
+  })
+
+  return diagnostics
 }

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -23,6 +23,7 @@ export const FIXTURE_URI = {
   MISSING_EXTENSION: `file://${path.join(FIXTURE_FOLDER, 'extension')}`,
   EXTENSION_INC: `file://${path.join(FIXTURE_FOLDER, 'extension.inc')}`,
   MISSING_NODE: `file://${path.join(FIXTURE_FOLDER, 'missing-node.sh')}`,
+  MISSING_NODE2: `file://${path.join(FIXTURE_FOLDER, 'missing-node2.sh')}`,
   OPTIONS: `file://${path.join(FIXTURE_FOLDER, 'options.sh')}`,
   OVERRIDE_SYMBOL: `file://${path.join(FIXTURE_FOLDER, 'override-executable-symbol.sh')}`,
   PARSE_PROBLEMS: `file://${path.join(FIXTURE_FOLDER, 'parse-problems.sh')}`,

--- a/testing/fixtures/missing-node2.sh
+++ b/testing/fixtures/missing-node2.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+a=14
+while :; do
+  # doc for function
+  random_op() {
+    # parsing issue: missing node ")", but is not reported as MISSING
+    a=$(((RANDOM % 1000) + 1))
+  }
+  # issue: hovering does not show documentation for function due to parsing error
+  random_op
+
+  sleep 2
+
+  echo $a
+done
+
+3

--- a/vscode-client/src/server.ts
+++ b/vscode-client/src/server.ts
@@ -20,7 +20,8 @@ connection.listen()
 
 // Don't die on unhandled Promise rejections
 process.on('unhandledRejection', (reason, p) => {
-  connection.console.error(`Unhandled Rejection at promise: ${p}, reason: ${reason}`)
+  const stack = reason instanceof Error ? reason.stack : reason
+  connection.console.error(`Unhandled Rejection at promise: ${p}, reason: ${stack}`)
 })
 
 process.on('SIGPIPE', () => {


### PR DESCRIPTION
Fixes https://github.com/bash-lsp/bash-language-server/issues/646  https://github.com/bash-lsp/bash-language-server/issues/670

In case of syntax issues in a file we are currently failing to parse declarations, which is used for features like on hover and goto definition. This was done to be defensive, but it is clear that we shouldn't fail in those cases.

While fixing this I added back in the diagnostics around missing nodes.

Thanks to @timoteicampian and @yusufaktepe  for the test cases.