### PR TITLE
Fix ShellCheck code actions not working on some clients

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -16,9 +16,9 @@ convenience - it proxies to the `package.json` files in the `vscode-client` and
 This guide presumes you have the following dependencies installed:
 
 - [`yarn`][yarn].
-- [`node`][node] (v6 or newer)
+- [`node`][node] (v14 or newer)
 - `g++`
-- `make`
+- `make` (optional)
 
 ## Initial setup
 
@@ -83,6 +83,20 @@ reload your vscode window to re-launch the server.
 
 ```
 yarn run reinstall-server
+```
+
+If you for some reason cannot get access to logs through the client,
+then you can hack the `server/util/logger` with:
+
+```typescript
+const fs = require('fs')
+const util = require('util')
+const log_file = fs.createWriteStream(`/tmp/bash-language-server-debug.log`, {
+  flags: 'w',
+})
+
+// inside log function
+log_file.write(`${severity} ${util.format(message)}\n`)
 ```
 
 ## Performance

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.6.1
+
+- Fix the ShellCheck code action feature that for some clients did not return any code actions. https://github.com/bash-lsp/bash-language-server/pull/700
+
 ## 4.6.0
 
 - Support parsing `: "${VARIABLE:="default"}"` as a variable definition https://github.com/bash-lsp/bash-language-server/pull/693

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -177,29 +177,30 @@ describe('server', () => {
       const fixableDiagnostic = diagnostics.filter(({ code }) => code === 'SC2086')[0]
 
       expect(fixableDiagnostic).toMatchInlineSnapshot(`
-              Object {
-                "code": "SC2086",
-                "codeDescription": Object {
-                  "href": "https://www.shellcheck.net/wiki/SC2086",
-                },
-                "message": "Double quote to prevent globbing and word splitting.",
-                "range": Object {
-                  "end": Object {
-                    "character": 13,
-                    "line": 55,
-                  },
-                  "start": Object {
-                    "character": 5,
-                    "line": 55,
-                  },
-                },
-                "severity": 3,
-                "source": "shellcheck",
-                "tags": undefined,
-              }
-          `)
-
-      // TODO: we could find the diagnostics and then use the range to test the code action
+        Object {
+          "code": "SC2086",
+          "codeDescription": Object {
+            "href": "https://www.shellcheck.net/wiki/SC2086",
+          },
+          "data": Object {
+            "id": "shellcheck|2086|55:5-55:13",
+          },
+          "message": "Double quote to prevent globbing and word splitting.",
+          "range": Object {
+            "end": Object {
+              "character": 13,
+              "line": 55,
+            },
+            "start": Object {
+              "character": 5,
+              "line": 55,
+            },
+          },
+          "severity": 3,
+          "source": "shellcheck",
+          "tags": undefined,
+        }
+      `)
 
       const onCodeAction = connection.onCodeAction.mock.calls[0][0]
 

--- a/server/src/shellcheck/__tests__/index.test.ts
+++ b/server/src/shellcheck/__tests__/index.test.ts
@@ -54,7 +54,7 @@ describe('linter', () => {
     })
 
     expect(result).toEqual({
-      codeActions: [],
+      codeActions: {},
       diagnostics: [],
     })
 
@@ -76,13 +76,16 @@ describe('linter', () => {
     const [result] = await getLintingResult({ document: textToDoc(shell) })
     expect(result).toMatchInlineSnapshot(`
       Object {
-        "codeActions": Array [
-          Object {
+        "codeActions": Object {
+          "shellcheck|2086|1:5-1:9": Object {
             "diagnostics": Array [
               Object {
                 "code": "SC2086",
                 "codeDescription": Object {
                   "href": "https://www.shellcheck.net/wiki/SC2086",
+                },
+                "data": Object {
+                  "id": "shellcheck|2086|1:5-1:9",
                 },
                 "message": "Double quote to prevent globbing and word splitting.",
                 "range": Object {
@@ -135,12 +138,15 @@ describe('linter', () => {
             "kind": "quickfix",
             "title": "Apply fix for SC2086",
           },
-        ],
+        },
         "diagnostics": Array [
           Object {
             "code": "SC2154",
             "codeDescription": Object {
               "href": "https://www.shellcheck.net/wiki/SC2154",
+            },
+            "data": Object {
+              "id": "shellcheck|2154|1:5-1:9",
             },
             "message": "foo is referenced but not assigned.",
             "range": Object {
@@ -161,6 +167,9 @@ describe('linter', () => {
             "code": "SC2086",
             "codeDescription": Object {
               "href": "https://www.shellcheck.net/wiki/SC2086",
+            },
+            "data": Object {
+              "id": "shellcheck|2086|1:5-1:9",
             },
             "message": "Double quote to prevent globbing and word splitting.",
             "range": Object {
@@ -197,7 +206,7 @@ describe('linter', () => {
 
     const result = await promises[promises.length - 1]
     expect(result).toEqual({
-      codeActions: [],
+      codeActions: {},
       diagnostics: [],
     })
   })
@@ -209,7 +218,7 @@ describe('linter', () => {
     })
 
     expect(result).toEqual({
-      codeActions: [],
+      codeActions: {},
       diagnostics: [],
     })
   })
@@ -222,12 +231,15 @@ describe('linter', () => {
 
     expect(result).toMatchInlineSnapshot(`
       Object {
-        "codeActions": Array [],
+        "codeActions": Object {},
         "diagnostics": Array [
           Object {
             "code": "SC1091",
             "codeDescription": Object {
               "href": "https://www.shellcheck.net/wiki/SC1091",
+            },
+            "data": Object {
+              "id": "shellcheck|1091|3:7-3:19",
             },
             "message": "Not following: shellcheck/sourced.sh: openBinaryFile: does not exist (No such file or directory)",
             "range": Object {
@@ -248,6 +260,9 @@ describe('linter', () => {
             "code": "SC2154",
             "codeDescription": Object {
               "href": "https://www.shellcheck.net/wiki/SC2154",
+            },
+            "data": Object {
+              "id": "shellcheck|2154|5:6-5:10",
             },
             "message": "foo is referenced but not assigned.",
             "range": Object {
@@ -276,7 +291,7 @@ describe('linter', () => {
       sourcePaths: [path.resolve(FIXTURE_FOLDER)],
     })
     expect(result).toEqual({
-      codeActions: [],
+      codeActions: {},
       diagnostics: [],
     })
   })


### PR DESCRIPTION
Closes https://github.com/bash-lsp/bash-language-server/issues/645 https://github.com/bash-lsp/bash-language-server/issues/490

I finally found time to debug the issues with missing code actions in neovim and Helix. Turns out that our silly fingerprinting for matching diagnostics with relevant code actions was only working for some clients that returned the context object using the same ordering of object keys. 🤕  No we simply create an `id` that we can match on – as [I originally wanted to](https://github.com/bash-lsp/bash-language-server/compare/fix-codeactions?expand=1#diff-323bbf013b4f95ca0f73d82df3bef434abd85fdd2875b41118059f606980b0a8R210) but never tested out...