### PR TITLE
Add fallback mechanism if `pkg-config` fails

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.7.0
+
+- Support for bash options auto completions when using Brew or when `pkg-config` fails, but bash completions are found in `"${PREFIX:-/usr}/share/bash-completion/bash_completion"` https://github.com/bash-lsp/bash-language-server/pull/717
+
 ## 4.6.2
 
 - Remove diagnostics for missing nodes that turns out to be unstable (this was introduced in 4.5.3) https://github.com/bash-lsp/bash-language-server/pull/708

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.6.2",
+  "version": "4.7.0",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/get-options.sh
+++ b/server/src/get-options.sh
@@ -1,15 +1,30 @@
 #!/usr/bin/env bash
 
+# Try and get COMPLETIONSRC using pkg-config
 COMPLETIONSDIR="$(pkg-config --variable=completionsdir bash-completion)"
-DATADIR="$(dirname "$(dirname "${COMPLETIONSDIR}")")"
 
-# Exit if bash-completion isn't installed.
-if (( $? != 0 ))
+if (( $? == 0 ))
+then
+	COMPLETIONSRC="$(dirname "$COMPLETIONSDIR")/bash_completion"
+else
+	# Fallback if pkg-config fails
+	if [ "$(uname -s)" = "Darwin" ]
+	then
+		# Running macOS
+		COMPLETIONSRC="$(brew --prefix)/etc/bash_completion"
+	else
+		# Suppose running Linux
+		COMPLETIONSRC="${PREFIX:-/usr}/share/bash-completion/bash_completion"
+	fi
+fi
+
+# Validate path of COMPLETIONSRC
+if (( $? != 0 )) || [ ! -r "$COMPLETIONSRC" ]
 then
 	exit 1
 fi
 
-source "$DATADIR/bash-completion/bash_completion"
+source "$COMPLETIONSRC"
 
 COMP_LINE="$*"
 COMP_WORDS=("$@")


### PR DESCRIPTION
`COMPLETIONSRC`: path to sourced `bash_completion`

If `pkg-config` fails to get `bash_completion` script:
- use `brew` on macOS
- use `PREFIX` on Linux