### PR TITLE
ShellCheck: Ensure parser does not throw an error

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.8.1
+
+- Ensure ShellCheck directive parse does not throw on malformed input https://github.com/bash-lsp/bash-language-server/pull/749
+
 ## 4.8.0
 
 - Use ShellCheck directives when analyzing source commands https://github.com/bash-lsp/bash-language-server/pull/747

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/shellcheck/__tests__/directive.test.ts
+++ b/server/src/shellcheck/__tests__/directive.test.ts
@@ -132,4 +132,15 @@ describe('parseShellCheckDirective', () => {
   it('parses a line with no directive', () => {
     expect(parseShellCheckDirective('# foo bar')).toEqual([])
   })
+
+  it('does not throw on invalid directives', () => {
+    expect(parseShellCheckDirective('# shellcheck')).toEqual([])
+    expect(parseShellCheckDirective('# shellcheck disable = ')).toEqual([])
+    expect(parseShellCheckDirective('# shellcheck disable=SC2-SC1')).toEqual([
+      { type: 'disable', rules: [] },
+    ])
+    expect(parseShellCheckDirective('# shellcheck disable=SC0-SC-1')).toEqual([
+      { type: 'disable', rules: ['SC0-SC-1'] },
+    ])
+  })
 })

--- a/server/src/shellcheck/directive.ts
+++ b/server/src/shellcheck/directive.ts
@@ -45,7 +45,7 @@ export function parseShellCheckDirective(line: string): Directive[] {
       ? (typeKey as DirectiveType)
       : null
 
-    if (!type) {
+    if (!type || !directiveValue) {
       continue
     }
 


### PR DESCRIPTION
Follow up on https://github.com/bash-lsp/bash-language-server/pull/747