### PR TITLE
server: Only perform dynamic registration if client supports it

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.8.3
+
+- Skip sending a `client/registerCapability` request when dynamic capability registration is not supported by the client https://github.com/bash-lsp/bash-language-server/pull/763
+
 ## 4.8.2
 
 - ShellCheck: avoid using the diagnostic tag "deprecated" that allow clients to render diagnostics with a strike through https://github.com/bash-lsp/bash-language-server/pull/753

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -138,6 +138,8 @@ export default class BashServer {
    */
   public register(connection: LSP.Connection): void {
     const hasConfigurationCapability = !!this.clientCapabilities?.workspace?.configuration
+    const canDynamicallyRegisterConfigurationChangeNotification =
+      !!this.clientCapabilities?.workspace?.didChangeConfiguration?.dynamicRegistration
 
     let currentDocument: TextDocument | null = null
     let initialized = false // Whether the client finished initializing
@@ -190,9 +192,11 @@ export default class BashServer {
 
       if (hasConfigurationCapability) {
         // Register event for all configuration changes.
-        connection.client.register(LSP.DidChangeConfigurationNotification.type, {
-          section: CONFIGURATION_SECTION,
-        })
+        if (canDynamicallyRegisterConfigurationChangeNotification) {
+          connection.client.register(LSP.DidChangeConfigurationNotification.type, {
+            section: CONFIGURATION_SECTION,
+          })
+        }
 
         // get current configuration from client
         const configObject = await connection.workspace.getConfiguration(


### PR DESCRIPTION
The server shouldn't send a `client/registerCapability` unless the client signals support with the dynamicRegistration client capability set to true for didChangeConfiguration. This change checks that field before attempting to register for config change notifications.

This change is important for clients that don't support dynamic capability registration: if we reply to the registerCapability request with a MethodNotHandled JSONRPC error, the promise from `connection.client.register` is rejected which causes the server to exit.