### PR TITLE
Make source error diagnostics configurable and off by default

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 4.8.4
+
+- Make source error diagnostics ("Source command could not be analyzed") configurable with the `enableSourceErrorDiagnostics` flag.
+
 ## 4.8.3
 
 - Skip sending a `client/registerCapability` request when dynamic capability registration is not supported by the client https://github.com/bash-lsp/bash-language-server/pull/763

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -107,7 +107,9 @@ describe('analyze', () => {
       Consider adding a ShellCheck directive above this line to fix or ignore this:
       # shellcheck source=/my-file.sh # specify the file to source
       # shellcheck source-path=my_script_folder # specify the folder to search in
-      # shellcheck source=/dev/null # to ignore the error",
+      # shellcheck source=/dev/null # to ignore the error
+
+      Disable this message by changing the configuration option "enableSourceErrorDiagnostics"",
           "range": {
             "end": {
               "character": 16,

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -814,6 +814,8 @@ describe('initiateBackgroundAnalysis', () => {
       [expect.stringContaining('missing-node2.sh: syntax error')],
       [expect.stringContaining('not-a-shell-script.sh: syntax error')],
       [expect.stringContaining('parse-problems.sh: syntax error')],
+      [expect.stringContaining('sourcing.sh line 16: failed to resolve path')],
+      [expect.stringContaining('sourcing.sh line 21: non-constant source not supported')],
     ])
 
     // Intro, stats on glob, one file skipped due to shebang, and outro

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -27,10 +27,12 @@ const loggerInfo = jest.spyOn(Logger.prototype, 'info')
 const loggerWarn = jest.spyOn(Logger.prototype, 'warn')
 
 async function getAnalyzer({
+  enableSourceErrorDiagnostics = false,
   includeAllWorkspaceSymbols = false,
   workspaceFolder = FIXTURE_FOLDER,
   runBackgroundAnalysis = false,
 }: {
+  enableSourceErrorDiagnostics?: boolean
   includeAllWorkspaceSymbols?: boolean
   workspaceFolder?: string
   runBackgroundAnalysis?: boolean
@@ -38,6 +40,7 @@ async function getAnalyzer({
   const parser = await initializeParser()
 
   const analyzer = new Analyzer({
+    enableSourceErrorDiagnostics,
     parser,
     includeAllWorkspaceSymbols,
     workspaceFolder,
@@ -87,7 +90,10 @@ describe('analyze', () => {
   })
 
   it('returns a list of diagnostics for a file with sourcing issues', async () => {
-    const analyzer = await getAnalyzer({})
+    const analyzer = await getAnalyzer({
+      enableSourceErrorDiagnostics: true,
+      includeAllWorkspaceSymbols: false,
+    })
     const diagnostics = analyzer.analyze({
       uri: CURRENT_URI,
       document: FIXTURE_DOCUMENT.SOURCING,
@@ -125,6 +131,15 @@ describe('analyze', () => {
       document: FIXTURE_DOCUMENT.SOURCING,
     })
     expect(diagnostics2).toEqual([])
+
+    // or if enableSourceErrorDiagnostics is false
+    analyzer.setIncludeAllWorkspaceSymbols(false)
+    analyzer.setEnableSourceErrorDiagnostics(false)
+    const diagnostics3 = analyzer.analyze({
+      uri: CURRENT_URI,
+      document: FIXTURE_DOCUMENT.SOURCING,
+    })
+    expect(diagnostics3).toEqual([])
   })
 })
 

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -6,6 +6,7 @@ describe('ConfigSchema', () => {
     expect(ConfigSchema.parse({})).toMatchInlineSnapshot(`
       {
         "backgroundAnalysisMaxFiles": 500,
+        "enableSourceErrorDiagnostics": false,
         "explainshellEndpoint": "",
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "includeAllWorkspaceSymbols": false,
@@ -28,6 +29,7 @@ describe('ConfigSchema', () => {
     ).toMatchInlineSnapshot(`
       {
         "backgroundAnalysisMaxFiles": 1,
+        "enableSourceErrorDiagnostics": false,
         "explainshellEndpoint": "localhost:8080",
         "globPattern": "**/*@(.sh)",
         "includeAllWorkspaceSymbols": true,
@@ -58,6 +60,7 @@ describe('getConfigFromEnvironmentVariables', () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "backgroundAnalysisMaxFiles": 500,
+        "enableSourceErrorDiagnostics": false,
         "explainshellEndpoint": "",
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "includeAllWorkspaceSymbols": false,
@@ -76,6 +79,7 @@ describe('getConfigFromEnvironmentVariables', () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "backgroundAnalysisMaxFiles": 500,
+        "enableSourceErrorDiagnostics": false,
         "explainshellEndpoint": "",
         "globPattern": "**/*@(.sh|.inc|.bash|.command)",
         "includeAllWorkspaceSymbols": false,
@@ -99,6 +103,7 @@ describe('getConfigFromEnvironmentVariables', () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "backgroundAnalysisMaxFiles": 1,
+        "enableSourceErrorDiagnostics": false,
         "explainshellEndpoint": "localhost:8080",
         "globPattern": "*.*",
         "includeAllWorkspaceSymbols": false,

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -95,29 +95,33 @@ export default class Analyzer {
       tree,
     }
 
-    const showSourceErrorDiagnostics =
-      this.enableSourceErrorDiagnostics && !this.includeAllWorkspaceSymbols
-    if (showSourceErrorDiagnostics) {
+    if (!this.includeAllWorkspaceSymbols) {
       sourceCommands
         .filter((sourceCommand) => sourceCommand.error)
         .forEach((sourceCommand) => {
-          diagnostics.push(
-            LSP.Diagnostic.create(
-              sourceCommand.range,
-              [
-                `Source command could not be analyzed: ${sourceCommand.error}.\n`,
-                'Consider adding a ShellCheck directive above this line to fix or ignore this:',
-                '# shellcheck source=/my-file.sh # specify the file to source',
-                '# shellcheck source-path=my_script_folder # specify the folder to search in',
-                '# shellcheck source=/dev/null # to ignore the error',
-                '',
-                'Disable this message by changing the configuration option "enableSourceErrorDiagnostics"',
-              ].join('\n'),
-              LSP.DiagnosticSeverity.Information,
-              undefined,
-              'bash-language-server',
-            ),
+          logger.warn(
+            `${uri} line ${sourceCommand.range.start.line}: ${sourceCommand.error}`,
           )
+
+          if (this.enableSourceErrorDiagnostics) {
+            diagnostics.push(
+              LSP.Diagnostic.create(
+                sourceCommand.range,
+                [
+                  `Source command could not be analyzed: ${sourceCommand.error}.\n`,
+                  'Consider adding a ShellCheck directive above this line to fix or ignore this:',
+                  '# shellcheck source=/my-file.sh # specify the file to source',
+                  '# shellcheck source-path=my_script_folder # specify the folder to search in',
+                  '# shellcheck source=/dev/null # to ignore the error',
+                  '',
+                  'Disable this message by changing the configuration option "enableSourceErrorDiagnostics"',
+                ].join('\n'),
+                LSP.DiagnosticSeverity.Information,
+                undefined,
+                'bash-language-server',
+              ),
+            )
+          }
         })
     }
 

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -34,20 +34,24 @@ type AnalyzedDocument = {
  * tree-sitter to find definitions, reference, etc.
  */
 export default class Analyzer {
+  private enableSourceErrorDiagnostics: boolean
   private includeAllWorkspaceSymbols: boolean
   private parser: Parser
   private uriToAnalyzedDocument: Record<string, AnalyzedDocument | undefined> = {}
   private workspaceFolder: string | null
 
   public constructor({
+    enableSourceErrorDiagnostics = false,
     includeAllWorkspaceSymbols = false,
     parser,
     workspaceFolder,
   }: {
+    enableSourceErrorDiagnostics?: boolean
     includeAllWorkspaceSymbols?: boolean
     parser: Parser
     workspaceFolder: string | null
   }) {
+    this.enableSourceErrorDiagnostics = enableSourceErrorDiagnostics
     this.includeAllWorkspaceSymbols = includeAllWorkspaceSymbols
     this.parser = parser
     this.workspaceFolder = workspaceFolder
@@ -91,7 +95,9 @@ export default class Analyzer {
       tree,
     }
 
-    if (!this.includeAllWorkspaceSymbols) {
+    const showSourceErrorDiagnostics =
+      this.enableSourceErrorDiagnostics && !this.includeAllWorkspaceSymbols
+    if (showSourceErrorDiagnostics) {
       sourceCommands
         .filter((sourceCommand) => sourceCommand.error)
         .forEach((sourceCommand) => {
@@ -511,6 +517,10 @@ export default class Analyzer {
       params.position.line,
       params.position.character,
     )
+  }
+
+  public setEnableSourceErrorDiagnostics(enableSourceErrorDiagnostics: boolean): void {
+    this.enableSourceErrorDiagnostics = enableSourceErrorDiagnostics
   }
 
   public setIncludeAllWorkspaceSymbols(includeAllWorkspaceSymbols: boolean): void {

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -110,6 +110,8 @@ export default class Analyzer {
                 '# shellcheck source=/my-file.sh # specify the file to source',
                 '# shellcheck source-path=my_script_folder # specify the folder to search in',
                 '# shellcheck source=/dev/null # to ignore the error',
+                '',
+                'Disable this message by changing the configuration option "enableSourceErrorDiagnostics"',
               ].join('\n'),
               LSP.DiagnosticSeverity.Information,
               undefined,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -20,7 +20,7 @@ export const ConfigSchema = z.object({
   logLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
 
   // Controls how symbols (e.g. variables and functions) are included and used for completion and documentation.
-  // If false, then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh').
+  // If false, then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh' or following ShellCheck directives).
   // If true, then all symbols from the workspace are included.
   includeAllWorkspaceSymbols: z.boolean().default(false),
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -6,6 +6,9 @@ export const ConfigSchema = z.object({
   // Maximum number of files to analyze in the background. Set to 0 to disable background analysis.
   backgroundAnalysisMaxFiles: z.number().int().min(0).default(500),
 
+  // Enable diagnostics for source errors. Ignored if includeAllWorkspaceSymbols is true.
+  enableSourceErrorDiagnostics: z.boolean().default(false),
+
   // Glob pattern for finding and parsing shell script files in the workspace. Used by the background analysis features across files.
   globPattern: z.string().trim().default('**/*@(.sh|.inc|.bash|.command)'),
 
@@ -47,6 +50,7 @@ export function getConfigFromEnvironmentVariables(): {
 } {
   const rawConfig = {
     backgroundAnalysisMaxFiles: toNumber(process.env.BACKGROUND_ANALYSIS_MAX_FILES),
+    enableSourceErrorDiagnostics: toBoolean(process.env.ENABLE_SOURCE_ERROR_DIAGNOSTICS),
     explainshellEndpoint: process.env.EXPLAINSHELL_ENDPOINT,
     globPattern: process.env.GLOB_PATTERN,
     includeAllWorkspaceSymbols: toBoolean(process.env.INCLUDE_ALL_WORKSPACE_SYMBOLS),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -269,6 +269,10 @@ export default class BashServer {
             this.linter = new Linter({ executablePath: shellcheckPath })
           }
 
+          this.analyzer.setEnableSourceErrorDiagnostics(
+            this.config.enableSourceErrorDiagnostics,
+          )
+
           this.analyzer.setIncludeAllWorkspaceSymbols(
             this.config.includeAllWorkspaceSymbols,
           )

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -55,7 +55,7 @@
         "bashIde.includeAllWorkspaceSymbols": {
           "type": "boolean",
           "default": false,
-          "description": "Controls how symbols (e.g. variables and functions) are included and used for completion and documentation. If false (default and recommended), then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh'). If true, then all symbols from the workspace are included."
+          "description": "Controls how symbols (e.g. variables and functions) are included and used for completion and documentation. If false (default and recommended), then we only include symbols from sourced files (i.e. using non dynamic statements like 'source file.sh' or '. file.sh' or following ShellCheck directives). If true, then all symbols from the workspace are included."
         },
         "bashIde.logLevel": {
           "type": "string",

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -37,6 +37,11 @@
           "description": "Maximum number of files to analyze in the background. Set to 0 to disable background analysis.",
           "minimum": 0
         },
+        "bashIde.enableSourceErrorDiagnostics": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable diagnostics for source errors. Ignored if includeAllWorkspaceSymbols is true."
+        },
         "bashIde.explainshellEndpoint": {
           "type": "string",
           "default": "",


### PR DESCRIPTION
Although the diagnostics message “Source command could not be analyzed” isn’t related to ShellCheck (it informs the user that jump to definition and documentation across files wouldn’t work and helps them resolve this by adding a ShellCheck directive), it seems to confuse multiple users: https://github.com/bash-lsp/bash-language-server/issues/790, https://github.com/bash-lsp/bash-language-server/issues/760, https://github.com/bash-lsp/bash-language-server/issues/738

Resolution: make it configurable using the new `enableSourceErrorDiagnostics` flag and disable it by default. We now always log the error to the console. 

I'm wondering if we should be less dramatic here and keep it on by default. 🤔 




