### PR TITLE
fix(man): Use cat as man pager

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Bash Language Server
 
+## 4.10.3
+
+- Use cat as man pager https://github.com/bash-lsp/bash-language-server/pull/909
+
+## 4.10.2
+
+- Bump semver development dependency causing false positive distributions security warnings https://github.com/bash-lsp/bash-language-server/pull/905
+
+
 ## 4.10.1
 
 - Handle tree-sitter-bash parse errors gracefully

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/util/sh.ts
+++ b/server/src/util/sh.ts
@@ -53,7 +53,7 @@ const WORDS_WITHOUT_DOCUMENTATION = new Set([
 ])
 
 /**
- * Get documentation for the given word by usingZZ help and man.
+ * Get documentation for the given word by using help and man.
  */
 export async function getShellDocumentationWithoutCache({
   word,
@@ -73,7 +73,7 @@ export async function getShellDocumentationWithoutCache({
     // We have experimented with setting MANWIDTH to different values for reformatting.
     // The default line width of the terminal works fine for hover, but could be better
     // for completions.
-    { type: 'man', command: `man ${word} | col -bx` },
+    { type: 'man', command: `man -P cat ${word} | col -bx` },
   ]
 
   for (const { type, command } of DOCUMENTATION_COMMANDS) {


### PR DESCRIPTION
Hi 👋, I ran into an issue when I configured Neovim as my default man pager via `export MANPAGER='nvim +Man!'`. bash-language-server is resolving commands with `man` but in my case `man` does not close because it is using Neovim. This can happen for any command in `MANPAGER` that doesn't exit. Below are a couple examples with different options:

### nvim 
![man-nvim](https://github.com/bash-lsp/bash-language-server/assets/10135646/90e6b551-9274-419c-bc4d-ffb4275b6dbf)

### less
![man-less](https://github.com/bash-lsp/bash-language-server/assets/10135646/03ba1843-cbee-47f7-aff7-cd43e9bfa740)

### cat
![man-cat](https://github.com/bash-lsp/bash-language-server/assets/10135646/186af189-3184-4d85-a0a7-dbba165b363c)

### vim
![man-vim](https://github.com/bash-lsp/bash-language-server/assets/10135646/13d431b5-aa75-474b-b82a-39f9282838cc)

In this PR I am explicitly settings the pager to `cat` to avoid unexpected formatting.

Please let me know if you have any questions or suggestions. Thanks!