### PR TITLE
feat: support leading dynamic section when sourcing

### DIFF
--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -123,6 +123,28 @@ describe('analyze', () => {
           "severity": 3,
           "source": "bash-language-server",
         },
+        {
+          "message": "Source command could not be analyzed: failed to resolve path.
+
+      Consider adding a ShellCheck directive above this line to fix or ignore this:
+      # shellcheck source=/my-file.sh # specify the file to source
+      # shellcheck source-path=my_script_folder # specify the folder to search in
+      # shellcheck source=/dev/null # to ignore the error
+
+      Disable this message by changing the configuration option "enableSourceErrorDiagnostics"",
+          "range": {
+            "end": {
+              "character": 49,
+              "line": 26,
+            },
+            "start": {
+              "character": 0,
+              "line": 26,
+            },
+          },
+          "severity": 3,
+          "source": "bash-language-server",
+        },
       ]
     `)
 
@@ -847,6 +869,7 @@ describe('initiateBackgroundAnalysis', () => {
       [expect.stringContaining('parse-problems.sh: syntax error')],
       [expect.stringContaining('sourcing.sh line 16: failed to resolve path')],
       [expect.stringContaining('sourcing.sh line 21: non-constant source not supported')],
+      [expect.stringContaining('sourcing.sh line 26: failed to resolve path')],
     ])
 
     // Intro, stats on glob, one file skipped due to shebang, and outro

--- a/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
+++ b/server/src/util/__tests__/__snapshots__/sourcing.test.ts.snap
@@ -87,18 +87,18 @@ exports[`getSourcedUris returns a set of sourced files (but ignores some unhandl
     "uri": null,
   },
   {
-    "error": "non-constant source not supported",
+    "error": null,
     "range": {
       "end": {
-        "character": 66,
-        "line": 16,
+        "character": 39,
+        "line": 15,
       },
       "start": {
-        "character": 49,
-        "line": 16,
+        "character": 6,
+        "line": 15,
       },
     },
-    "uri": null,
+    "uri": "file:///Users/bash/issue-926.sh",
   },
   {
     "error": "non-constant source not supported",
@@ -108,8 +108,22 @@ exports[`getSourcedUris returns a set of sourced files (but ignores some unhandl
         "line": 18,
       },
       "start": {
-        "character": 6,
+        "character": 49,
         "line": 18,
+      },
+    },
+    "uri": null,
+  },
+  {
+    "error": "non-constant source not supported",
+    "range": {
+      "end": {
+        "character": 66,
+        "line": 20,
+      },
+      "start": {
+        "character": 6,
+        "line": 20,
       },
     },
     "uri": null,
@@ -119,11 +133,11 @@ exports[`getSourcedUris returns a set of sourced files (but ignores some unhandl
     "range": {
       "end": {
         "character": 30,
-        "line": 25,
+        "line": 27,
       },
       "start": {
         "character": 8,
-        "line": 25,
+        "line": 27,
       },
     },
     "uri": "file:///Users/bash/issue206.sh",
@@ -133,53 +147,53 @@ exports[`getSourcedUris returns a set of sourced files (but ignores some unhandl
     "range": {
       "end": {
         "character": 22,
-        "line": 47,
+        "line": 49,
       },
       "start": {
         "character": 8,
-        "line": 47,
+        "line": 49,
       },
     },
     "uri": null,
   },
   {
-    "error": "non-constant source not supported",
+    "error": null,
     "range": {
       "end": {
         "character": 39,
-        "line": 59,
+        "line": 61,
       },
       "start": {
         "character": 8,
-        "line": 59,
+        "line": 61,
       },
     },
-    "uri": null,
+    "uri": "file:///Users/bash/staging.sh",
   },
   {
-    "error": "non-constant source not supported",
+    "error": null,
     "range": {
       "end": {
         "character": 42,
-        "line": 62,
+        "line": 64,
       },
       "start": {
         "character": 8,
-        "line": 62,
+        "line": 64,
       },
     },
-    "uri": null,
+    "uri": "file:///Users/bash/production.sh",
   },
   {
     "error": "non-constant source not supported",
     "range": {
       "end": {
         "character": 67,
-        "line": 89,
+        "line": 91,
       },
       "start": {
         "character": 10,
-        "line": 89,
+        "line": 91,
       },
     },
     "uri": null,

--- a/server/src/util/__tests__/sourcing.test.ts
+++ b/server/src/util/__tests__/sourcing.test.ts
@@ -46,6 +46,8 @@ describe('getSourcedUris', () => {
 
       source "$LIBPATH" # dynamic imports not supported
 
+      source "$SCRIPT_DIR"/issue-926.sh # remove leading dynamic segment
+
       # conditional is currently not supported
       if [[ -z $__COMPLETION_LIB_LOADED ]]; then source "$LIBPATH" ; fi
 
@@ -144,7 +146,10 @@ describe('getSourcedUris', () => {
         "file:///Users/bash/x",
         "file:///Users/scripts/release-client.sh",
         "file:///Users/bash-user/myscript",
+        "file:///Users/bash/issue-926.sh",
         "file:///Users/bash/issue206.sh",
+        "file:///Users/bash/staging.sh",
+        "file:///Users/bash/production.sh",
       }
     `)
 

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -23,3 +23,5 @@ loadlib () {
 }
 
 loadlib "issue206"
+
+source $SCRIPT_DIR/tag-release.inc with arguments


### PR DESCRIPTION
This does the same thing that ShellCheck does ([here](https://github.com/koalaman/shellcheck/blob/ba86c6363c30a5dbefd0b8b9a7c5f4ab0478dc91/src/ShellCheck/Parser.hs#L2277-L2283)).

`To support the common pattern of . "$CONFIGDIR/mylib.sh", ShellCheck strips one leading, dynamic section before trying to locate the rest.`

fixes #926, fixes #659
