### PR TITLE
fix(snippets): case statement should end with `esac`

### DIFF
--- a/server/src/snippets.ts
+++ b/server/src/snippets.ts
@@ -459,7 +459,7 @@ export const SNIPPETS: BashCompletionItem[] = [
       '\t*)',
       '\t\t${4:command ...}',
       '\t\t;;',
-      'end',
+      'esac',
     ].join('\n'),
   },
   {


### PR DESCRIPTION
Changed `end` to `esac`