### PR TITLE
Fix pnpm add flags

### DIFF
--- a/scripts/upgrade-tree-sitter.sh
+++ b/scripts/upgrade-tree-sitter.sh
@@ -4,7 +4,7 @@ set -euox pipefail
 
 cd server
 pnpm add web-tree-sitter
-pnpm add --dev tree-sitter-cli https://github.com/tree-sitter/tree-sitter-bash
+pnpm add --save-dev tree-sitter-cli https://github.com/tree-sitter/tree-sitter-bash
 npx tree-sitter build-wasm node_modules/tree-sitter-bash
 
 curl 'https://api.github.com/repos/tree-sitter/tree-sitter-bash/commits/master' | jq .commit.url > parser.info


### PR DESCRIPTION
It looks like when the repository was refactored from yarn-> pnpm, the --dev flag was not updated properly.

This causes the auto update of treesitter to fail(https://github.com/bash-lsp/bash-language-server/pull/1115)

https://pnpm.io/cli/add#--save-dev--d