### PR TITLE
Update release-client.sh script

### DIFF
--- a/scripts/release-client.sh
+++ b/scripts/release-client.sh
@@ -13,5 +13,5 @@ pnpm verify:bail
 
 cd vscode-client
 
-# NOTE: it would be much nicer if we could detect which version was deployed...
-npx vsce@1.103.1 publish -p $VSCE_TOKEN && tagRelease $tag || echo 'Deploy failed, probably there was no changes'
+npx @vscode/vsce@2.26.0 publish --skip-duplicate -p $VSCE_TOKEN 
+tagRelease $tag || echo "Tag update failed, likely already exists"

--- a/server/src/__tests__/__snapshots__/server.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/server.test.ts.snap
@@ -653,11 +653,11 @@ exports[`server onRenameRequest Workspace-wide rename returns correct WorkspaceE
         "newText": "newName",
         "range": {
           "end": {
-            "character": 53,
+            "character": 10,
             "line": 16,
           },
           "start": {
-            "character": 43,
+            "character": 0,
             "line": 16,
           },
         },


### PR DESCRIPTION
Update vscde to latest version (vsce is depresated in favor of @vscode/vsce) 

The current code has an `|| echo` that masks failures from vsce publish, in order to not fail the pipeline when the published version already exists.

The latest version of vsce adds a --skip-duplicate flag, this allows us to fail silently if the version already exists on the marketplace, so IMO this is a better way to handle that





