### PR TITLE
Install shellcheck and shfmt for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install shellcheck and shfmt (used for testing)
+        run: sudo apt-get install -y shellcheck shfmt
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8


### PR DESCRIPTION
The merge of my `shfmt` changes broke the `deploy` workflow. Both of the release scripts call `pnpm verify:bail` (which runs the test suite), so these test dependencies need to be installed here as well.

Although `shellcheck` is included in GitHub's `ubuntu-latest` build image, we explicitly install it here both for consistency with the `verify` workflow and as a guard against this being removed from the build image in future.