### PR TITLE
fix(snippets): fixed existence-check snippets 

### DIFF
--- a/server/src/snippets.ts
+++ b/server/src/snippets.ts
@@ -153,16 +153,20 @@ export const SNIPPETS: BashCompletionItem[] = [
   {
     label: 'if-defined',
     documentation: 'if with variable existence check',
-    insertText: ['if [[ -n "${${1:variable}+x}" ]]', '\t${2:command ...}', 'fi'].join(
-      '\n',
-    ),
+    insertText: [
+      'if [[ -n "${${1:variable}+x}" ]]; then',
+      '\t${2:command ...}',
+      'fi',
+    ].join('\n'),
   },
   {
     label: 'if-not-defined',
     documentation: 'if with variable existence check',
-    insertText: ['if [[ -z "${${1:variable}+x}" ]]', '\t${2:command ...}', 'fi'].join(
-      '\n',
-    ),
+    insertText: [
+      'if [[ -z "${${1:variable}+x}" ]]; then',
+      '\t${2:command ...}',
+      'fi',
+    ].join('\n'),
   },
   {
     label: 'while',


### PR DESCRIPTION
### Snippet-Fix
As of now, the "if-defined" and "if-not-defined" snippets are missing `; then` after the condition, which results in broken snippets (see below)
```
$ cat test.sh
# if-defined
if [[ -n "${variable+x}" ]]
    command ...
fi

# if-not-defined
if [[ -z "${variable+x}" ]]
    command ...
if

$ shellcheck test.sh

In test.sh line 2:
if [[ -n "${variable+x}" ]]
^-- SC1049 (error): Did you forget the 'then' for this 'if'?
^-- SC1073 (error): Couldn't parse this if expression. Fix to allow more checks.


In test.sh line 4:
fi
^-- SC1050 (error): Expected 'then'.
  ^-- SC1072 (error): Unexpected keyword/token. Fix any mentioned problems and try again.

For more information:
  https://www.shellcheck.net/wiki/SC1049 -- Did you forget the 'then' for thi...
  https://www.shellcheck.net/wiki/SC1050 -- Expected 'then'.
  https://www.shellcheck.net/wiki/SC1072 -- Unexpected keyword/token. Fix any...

``` 
