### PR TITLE
Handle non-zero exit status when formatting using shfmt

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 5.3.2
+
+- Handle non-zero exit status when formatting using shfmt https://github.com/bash-lsp/bash-language-server/pull/1163
+
 ## 5.3.1
 
 - Clear diagnostics when closing document https://github.com/bash-lsp/bash-language-server/pull/1135

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",
   "bin": {

--- a/server/src/shfmt/__tests__/index.test.ts
+++ b/server/src/shfmt/__tests__/index.test.ts
@@ -38,7 +38,7 @@ describe('formatter', () => {
     expect(new Formatter({ executablePath: 'foo' }).canFormat).toBe(true)
   })
 
-  it('should set canFormat to false when formatting fails', async () => {
+  it('should set canFormat to false when the executable cannot be found', async () => {
     const [result, formatter] = await getFormattingResult({
       document: textToDoc(''),
       executablePath: 'foo',
@@ -51,6 +51,14 @@ describe('formatter', () => {
       expect.stringContaining(
         'Shfmt: disabling formatting as no executable was found at path',
       ),
+    )
+  })
+
+  it('should throw when formatting fails', async () => {
+    expect(async () => {
+      await getFormattingResult({ document: FIXTURE_DOCUMENT.PARSE_PROBLEMS })
+    }).rejects.toThrow(
+      'Shfmt: exited with status 1: <standard input>:10:1: > must be followed by a word',
     )
   })
 

--- a/server/src/shfmt/index.ts
+++ b/server/src/shfmt/index.ts
@@ -91,14 +91,10 @@ export class Formatter {
       proc.stdin.end(documentText)
     })
 
-    // NOTE: do we care about exit code? 0 means "ok", 1 possibly means "errors",
-    // but the presence of parseable errors in the output is also sufficient to
-    // distinguish.
     let exit
     try {
       exit = await proc
     } catch (e) {
-      // TODO: we could do this up front?
       if ((e as any).code === 'ENOENT') {
         // shfmt path wasn't found, don't try to format any more:
         logger.warn(
@@ -107,7 +103,11 @@ export class Formatter {
         this._canFormat = false
         return ''
       }
-      throw new Error(`Shfmt: failed with code ${exit}: ${e}\nout:\n${out}\nerr:\n${err}`)
+      throw new Error(`Shfmt: child process error: ${e}`)
+    }
+
+    if (exit != 0) {
+      throw new Error(`Shfmt: exited with status ${exit}: ${err}`)
     }
 
     return out


### PR DESCRIPTION
Non-zero exist statuses from `shfmt` weren't checked for or handled. As a result the (empty) output from `shfmt` was returned as the formatted document. An exception is now thrown when a non-zero exit status is encountered.

Fixes #1162