### PR TITLE
fix: escape literal `$` in `for-range` snippets

### DIFF
--- a/server/src/snippets.ts
+++ b/server/src/snippets.ts
@@ -429,7 +429,7 @@ export const SNIPPETS: BashCompletionItem[] = [
     label: 'for-range',
     documentation: 'for with range',
     insertText: [
-      'for ${1:item} in $(seq ${2:from} ${3:to}); do',
+      'for ${1:item} in \\$(seq ${2:from} ${3:to}); do',
       '\t${4:command ...}',
       'done',
     ].join('\n'),
@@ -438,7 +438,7 @@ export const SNIPPETS: BashCompletionItem[] = [
     label: 'for-stepped-range',
     documentation: 'for with stepped range',
     insertText: [
-      'for ${1:item} in $(seq ${2:from} ${3:step} ${4:to}); do',
+      'for ${1:item} in \\$(seq ${2:from} ${3:step} ${4:to}); do',
       '\t${5:command ...}',
       'done',
     ].join('\n'),


### PR DESCRIPTION
Unescaped, they make the snippets invalid; using the builtin snippet expansion from neovim, those two range snippets result in the error `...10.1/share/nvim/runtime/lua/vim/lsp/_snippet_grammar.lua:177: snippet parsing failed`