### PR TITLE
fix(logs): prevent shfmt environment variable deprecation warning

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -102,9 +102,12 @@ export function getConfigFromEnvironmentVariables(): {
   }
 
   const environmentVariablesUsed = Object.entries(rawConfig)
-    .map(([key, value]) => (typeof value !== 'undefined' ? key : null))
-    .filter((key): key is string => key !== null)
-    .filter((key) => key !== 'logLevel') // logLevel is a special case that we ignore
+    .filter(
+      ([key, value]) =>
+        !['undefined', 'object'].includes(typeof value) &&
+        ![null, 'logLevel'].includes(key),
+    )
+    .map(([key]) => key)
 
   const config = ConfigSchema.parse(rawConfig)
 


### PR DESCRIPTION
Prevent consistent warnings in the log file about deprecated shfmt environment variables. The change also slightly improves performance by reducing the iterations. 

Alternatively, I could check the `shfmt` object for environment variable usage instead of skipping them like `logLevel`. Let me know what you'd prefer!

Fixes #1226
