### PR TITLE
fix(analyser): Fixed incorrect URL construction for ExplainShell API …

### DIFF
--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -633,7 +633,7 @@ export default class Analyzer {
     }
 
     const searchParams = new URLSearchParams({ cmd: interestingNode.text }).toString()
-    const url = `${endpoint}/api/explain?${searchParams}`
+    const url = `${endpoint}/explain?${searchParams}`
 
     const explainshellRawResponse = await fetch(url)
     const explainshellResponse =


### PR DESCRIPTION
…calls

- Corrected the `url` variable to remove the deprecated `/api/` prefix in the endpoint

Addresses #1107 