### PR TITLE
Publish extension to Open VSX

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
         name: Deploy VS Code extension
         env:
           VSCE_TOKEN: ${{ secrets.VSCE_PERSONAL_ACCESS_TOKEN }}
+          OVSX_TOKEN: ${{ secrets.OVSX_PERSONAL_ACCESS_TOKEN }}
 
       - run: bash scripts/release-server.sh
         name: Deploy server

--- a/scripts/release-client.sh
+++ b/scripts/release-client.sh
@@ -13,5 +13,6 @@ pnpm verify:bail
 
 cd vscode-client
 
-npx @vscode/vsce@2.26.0 publish --skip-duplicate -p $VSCE_TOKEN 
+npx @vscode/vsce@2.26.0 publish --skip-duplicate -p $VSCE_TOKEN
+npx ovsx                publish --skip-duplicate -p $OVSX_TOKEN
 tagRelease $tag || echo "Tag update failed, likely already exists"


### PR DESCRIPTION
The vscode-client is published to the VSCode Marketplace in every release. And there was the extension published in OpenVSX by [_OpenVSX_](https://open-vsx.org/extension/mads-hartmann/bash-ide-vscode) for Code-OSS and VSCodium users, but this extension has become very outdated and misses the new features like support for `shfmt`.

There is [detailed information](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions) on how to publish the extension to OpenVSX.

I opened this skeleton PR mostly to see if there is some interest to make this happen. Hopefully :crossed_fingers: 

Fixes #1180 