### PR TITLE
feat: add shellcheckExternalSources config to make --external-sources optional

### DIFF
--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -12,6 +12,7 @@ describe('ConfigSchema', () => {
         "includeAllWorkspaceSymbols": false,
         "logLevel": "info",
         "shellcheckArguments": [],
+        "shellcheckExternalSources": true,
         "shellcheckPath": "shellcheck",
         "shfmt": {
           "binaryNextLine": false,
@@ -62,6 +63,7 @@ describe('ConfigSchema', () => {
           "-e",
           "SC2002",
         ],
+        "shellcheckExternalSources": true,
         "shellcheckPath": "",
         "shfmt": {
           "binaryNextLine": true,
@@ -99,6 +101,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "includeAllWorkspaceSymbols": false,
         "logLevel": "info",
         "shellcheckArguments": [],
+        "shellcheckExternalSources": true,
         "shellcheckPath": "shellcheck",
         "shfmt": {
           "binaryNextLine": false,
@@ -130,6 +133,7 @@ describe('getConfigFromEnvironmentVariables', () => {
         "includeAllWorkspaceSymbols": false,
         "logLevel": "info",
         "shellcheckArguments": [],
+        "shellcheckExternalSources": true,
         "shellcheckPath": "",
         "shfmt": {
           "binaryNextLine": false,
@@ -170,6 +174,7 @@ describe('getConfigFromEnvironmentVariables', () => {
           "-e",
           "SC2001",
         ],
+        "shellcheckExternalSources": true,
         "shellcheckPath": "/path/to/shellcheck",
         "shfmt": {
           "binaryNextLine": false,

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,7 +24,12 @@ export const ConfigSchema = z.object({
   // If true, then all symbols from the workspace are included.
   includeAllWorkspaceSymbols: z.boolean().default(false),
 
-  // Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, --external-sources."
+  // Controls whether ShellCheck is invoked with --external-sources. When enabled (default),
+  // ShellCheck follows source directives to lint referenced files. On projects with many
+  // cross-sourcing scripts this can cause unbounded memory growth. Set to false to disable.
+  shellcheckExternalSources: z.boolean().default(true),
+
+  // Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, and --external-sources (if shellcheckExternalSources is true).
   shellcheckArguments: z
     .preprocess((arg) => {
       let argsList: string[] = []
@@ -87,6 +92,7 @@ export function getConfigFromEnvironmentVariables(): {
     includeAllWorkspaceSymbols: toBoolean(process.env.INCLUDE_ALL_WORKSPACE_SYMBOLS),
     logLevel: process.env[LOG_LEVEL_ENV_VAR],
     shellcheckArguments: process.env.SHELLCHECK_ARGUMENTS,
+    shellcheckExternalSources: toBoolean(process.env.SHELLCHECK_EXTERNAL_SOURCES),
     shellcheckPath: process.env.SHELLCHECK_PATH,
     shfmt: {
       path: process.env.SHFMT_PATH,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -277,7 +277,10 @@ export default class BashServer {
             logger.info('ShellCheck linting is disabled as "shellcheckPath" was not set')
             this.linter = undefined
           } else {
-            this.linter = new Linter({ executablePath: shellcheckPath })
+            this.linter = new Linter({
+              executablePath: shellcheckPath,
+              externalSources: this.config.shellcheckExternalSources,
+            })
           }
 
           const shfmtPath = this.config.shfmt?.path

--- a/server/src/shellcheck/index.ts
+++ b/server/src/shellcheck/index.ts
@@ -33,6 +33,7 @@ function safeFileURLToPath(uri: string): string | null {
 type LinterOptions = {
   executablePath: string
   cwd?: string
+  externalSources?: boolean
 }
 
 export type LintingResult = {
@@ -43,15 +44,17 @@ export type LintingResult = {
 export class Linter {
   private cwd: string
   public executablePath: string
+  private externalSources: boolean
   private uriToDebouncedExecuteLint: {
     [uri: string]: InstanceType<typeof Linter>['executeLint']
   }
   private _canLint: boolean
 
-  constructor({ cwd, executablePath }: LinterOptions) {
+  constructor({ cwd, executablePath, externalSources = true }: LinterOptions) {
     this._canLint = true
     this.cwd = cwd || process.cwd()
     this.executablePath = executablePath
+    this.externalSources = externalSources
     this.uriToDebouncedExecuteLint = Object.create(null)
   }
 
@@ -139,7 +142,7 @@ export class Linter {
 
     const args = [
       '--format=json1',
-      '--external-sources',
+      ...(this.externalSources ? ['--external-sources'] : []),
       ...sourcePathsArgs,
       ...additionalArgs,
     ]

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -73,10 +73,15 @@
           "default": "shellcheck",
           "description": "Controls the executable used for ShellCheck linting information. An empty string will disable linting."
         },
+        "bashIde.shellcheckExternalSources": {
+          "type": "boolean",
+          "default": true,
+          "description": "Controls whether ShellCheck is invoked with --external-sources. When enabled (default), ShellCheck follows source directives to lint referenced files. On projects with many cross-sourcing scripts this can cause unbounded memory growth. Set to false to disable."
+        },
         "bashIde.shellcheckArguments": {
           "type": "string",
           "default": "",
-          "description": "Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, --external-sources."
+          "description": "Additional ShellCheck arguments. Note that we already add the following arguments: --shell, --format, and --external-sources (if shellcheckExternalSources is true)."
         },
         "bashIde.shfmt.path": {
           "type": "string",


### PR DESCRIPTION
## Summary

Adds a `shellcheckExternalSources` boolean config option (default: `true` for backward compatibility) that controls whether `--external-sources` is passed to ShellCheck. When set to `false`, the flag is omitted, preventing unbounded memory growth on projects with many cross-sourcing shell scripts.

## Problem

The `--external-sources` flag is currently hardcoded in every ShellCheck invocation ([`server/src/shellcheck/index.ts:142`](https://github.com/bash-lsp/bash-language-server/blob/main/server/src/shellcheck/index.ts#L142)). On projects with many shell scripts that cross-source each other (e.g. 100+ scripts with `source-path=SCRIPTDIR` in `.shellcheckrc`), this causes exponential AST expansion — individual shellcheck processes grow to **3-5 GB RSS** and never terminate.

With multiple editor sessions or headless AI coding tools (opencode, Claude Code) each spawning their own bash-language-server, this compounds rapidly. We observed **73 concurrent shellcheck processes consuming 17.8 GB RAM** on a 64 GB machine.

The existing `shellcheckArguments` config only *appends* arguments — there's no way to *remove* the hardcoded `--external-sources`.

## Changes

| File | Change |
|------|--------|
| `server/src/config.ts` | Add `shellcheckExternalSources` boolean config (default `true`) and `SHELLCHECK_EXTERNAL_SOURCES` env var |
| `server/src/shellcheck/index.ts` | Add `externalSources` to `LinterOptions`, conditionally include `--external-sources` |
| `server/src/server.ts` | Pass `config.shellcheckExternalSources` when constructing `Linter` |
| `vscode-client/package.json` | Add `bashIde.shellcheckExternalSources` VS Code setting |

## Usage

**VS Code setting:**
```json
{
  "bashIde.shellcheckExternalSources": false
}
```

**Environment variable:**
```bash
SHELLCHECK_EXTERNAL_SOURCES=false
```

**LSP initialization (for non-VS Code editors):**
```json
{
  "shellcheckExternalSources": false
}
```

## Backward Compatibility

Default is `true` — existing behavior is unchanged. Only users who explicitly set it to `false` will see the difference.

Fixes #874
Fixes #1375