### PR TITLE
test: fix shfmt error message assertions

### DIFF
--- a/server/src/shfmt/__tests__/index.test.ts
+++ b/server/src/shfmt/__tests__/index.test.ts
@@ -55,21 +55,21 @@ describe('formatter', () => {
   })
 
   it('should throw when formatting fails', async () => {
-    expect(async () => {
+    await expect(async () => {
       await getFormattingResult({ document: FIXTURE_DOCUMENT.PARSE_PROBLEMS })
     }).rejects.toThrow(
-      /Shfmt: exited with status 1: .*\/testing\/fixtures\/parse-problems.sh:10:1: > must be followed by a word/,
+      /Shfmt: exited with status 1: .*\/testing\/fixtures\/parse-problems.sh:10:1: [`"']?>[`"']? must be followed by a word/,
     )
   })
 
   it('should throw when parsing using the wrong language dialect', async () => {
-    expect(async () => {
+    await expect(async () => {
       await getFormattingResult({
         document: FIXTURE_DOCUMENT.SHFMT,
         shfmtConfig: { languageDialect: 'posix' },
       })
     }).rejects.toThrow(
-      /Shfmt: exited with status 1: .*\/testing\/fixtures\/shfmt\.sh:25:14: (the "function" builtin|a command can only contain words and redirects; encountered \()/,
+      /Shfmt: exited with status 1: .*\/testing\/fixtures\/shfmt\.sh:25:14: (the [`"']?function[`"']? builtin|a command can only contain words and redirects; encountered \()/,
     )
   })
 
@@ -607,10 +607,10 @@ describe('formatter', () => {
       FIXTURE_DOCUMENT.PARSE_PROBLEMS.getText(),
     )
 
-    expect(async () => {
+    await expect(async () => {
       await getFormattingResult({ document: testDocument })
     }).rejects.toThrow(
-      /Shfmt: exited with status 1: <standard input>:10:1: > must be followed by a word/,
+      /Shfmt: exited with status 1: <standard input>:10:1: [`"']?>[`"']? must be followed by a word/,
     )
   })
 


### PR DESCRIPTION
The formatter tests fail against shfmt >= 3.13 (I hit this on Fedora with shfmt 3.13.1, on current `main`, unrelated to any local change).

### Changed error messages

mvdan/sh [16cc925dc](https://github.com/mvdan/sh/commit/16cc925dc) ("syntax: consistently quote tokens in error messages") landed in shfmt 3.13.0, so two messages the tests match on now look different:

```
-  parse-problems.sh:10:1: > must be followed by a word
+  parse-problems.sh:10:1: `>` must be followed by a word

-  shfmt.sh:25:14: the "function" builtin is a bash feature; tried parsing as posix
+  shfmt.sh:25:14: the `function` builtin is a bash feature; tried parsing as posix
```

The assertions now accept either quoting style, alongside the pre-existing alternative for much older shfmt versions.

CI does not see this because `verify.yml` installs shfmt via `apt-get`, and the version in the Ubuntu archive predates 3.13.

### Missing `await`

While tracking this down: the three `expect(...).rejects.toThrow(...)` assertions in this file were never awaited or returned. The test therefore finished green and the rejection surfaced during whichever test ran *next* — so jest blamed `should format when shfmt is present` for a message belonging to `should throw when parsing using the wrong language dialect`, which made this a good deal more confusing than it needed to be.

Verified the assertions actually bite now: deliberately corrupting the expected strings fails the tests that own them, rather than their neighbours.