### PR TITLE
ci: also run the tests against the latest shfmt

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -68,3 +68,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./codecov.yml
+
+  all-done:
+    needs:
+      - verify
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "All jobs completed"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,15 +7,45 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    name: verify (node ${{ matrix.node-version }}, ${{ matrix.shfmt }} shfmt)
+
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x]
+        shfmt: [distro]
+        include:
+          # shfmt occasionally changes its output and its error messages, which
+          # the formatter tests assert on. The archive version lags well behind,
+          # so run one job against the latest release to catch such changes when
+          # they happen rather than when a user reports them.
+          - node-version: 22.x
+            shfmt: latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install shellcheck and shfmt (used for testing)
-        run: sudo apt-get install -y shellcheck shfmt
+      - name: Install shellcheck (used for testing)
+        run: sudo apt-get install -y shellcheck
+
+      - name: Install shfmt from the Ubuntu archive (used for testing)
+        if: matrix.shfmt == 'distro'
+        run: sudo apt-get install -y shfmt
+
+      - name: Install the latest shfmt release (used for testing)
+        if: matrix.shfmt == 'latest'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh release view --repo mvdan/sh --json tagName --jq .tagName)
+          sudo curl -fsSL -o /usr/local/bin/shfmt \
+            "https://github.com/mvdan/sh/releases/download/$tag/shfmt_${tag}_linux_amd64"
+          sudo chmod +x /usr/local/bin/shfmt
+
+      - name: Show which shfmt is used
+        run: |
+          command -v shfmt
+          shfmt --version
 
       - uses: pnpm/action-setup@v4
         with:
@@ -34,7 +64,7 @@ jobs:
 
       - name: Publish coverage to codecov.io
         uses: codecov/codecov-action@v5
-        if: success() && matrix.node-version == '22.x'
+        if: success() && matrix.node-version == '22.x' && matrix.shfmt == 'distro'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./codecov.yml


### PR DESCRIPTION
~~Builds on #1393 — please merge that first, otherwise the new job is red on arrival. The first commit here is that PR's.~~

### Why

The formatter tests assert on shfmt's output and on its error messages, and both change from time to time. CI installs shfmt from the Ubuntu archive, which lags well behind upstream, so such a change is only noticed once someone on a more current distribution runs the test suite and reports it — which is exactly how #1393 came about (Fedora ships shfmt 3.13.1; the archive is older).

### What

One extra job running against the latest shfmt release. It is an `include:` entry rather than a second matrix axis, so this costs a single job rather than doubling the matrix:

```
verify (node 20.x, distro shfmt)
verify (node 22.x, distro shfmt)
verify (node 22.x, latest shfmt)
```

Notes:

- The archive shfmt is now installed only in the jobs that ask for it, so the two are never on `PATH` together and the result does not depend on `/usr/local/bin` preceding `/usr/bin`.
- `fail-fast: false`, so a break in the latest-shfmt job does not cancel the others.
- The codecov upload is pinned to one job, as before.
- A step prints `command -v shfmt` and `shfmt --version`, so a failure log says up front which binary produced it.

### Tradeoff worth a maintainer opinion

Resolving "latest" at run time means a new shfmt release can turn a PR red for reasons unrelated to that PR. That is the point of the job, but if you would rather have deterministic CI, the alternative is pinning a version here and letting renovate bump it — the signal arrives as a renovate PR instead of on someone else's. Happy to switch it over if you prefer that.