### PR TITLE
fix: prevent out of memory crash on cyclic symbolic links

### DIFF
--- a/server/src/util/__tests__/fs.test.ts
+++ b/server/src/util/__tests__/fs.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { getFilePaths } from '../fs'
+
+const symlinkType = process.platform === 'win32' ? 'junction' : 'dir'
+
+const relativePaths = (filePaths: string[], rootPath: string): string[] =>
+  filePaths.map((filePath) => path.relative(rootPath, filePath).split(path.sep).join('/'))
+
+describe('getFilePaths', () => {
+  let rootPath: string
+
+  beforeEach(() => {
+    rootPath = fs.mkdtempSync(path.join(os.tmpdir(), 'bash-language-server-fs-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(rootPath, { recursive: true, force: true })
+  })
+
+  it('returns the paths of files matching the glob pattern', async () => {
+    fs.writeFileSync(path.join(rootPath, 'script.sh'), '')
+    fs.mkdirSync(path.join(rootPath, 'nested'))
+    fs.writeFileSync(path.join(rootPath, 'nested', 'nested.sh'), '')
+
+    const filePaths = await getFilePaths({
+      globPattern: '**/*.sh',
+      rootPath,
+      maxItems: 100,
+    })
+
+    expect(relativePaths(filePaths, rootPath).sort()).toEqual([
+      'nested/nested.sh',
+      'script.sh',
+    ])
+  })
+
+  it('follows symbolic links to directories', async () => {
+    const targetPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bash-language-server-fs-target-'),
+    )
+
+    try {
+      fs.writeFileSync(path.join(targetPath, 'linked.sh'), '')
+      fs.symlinkSync(targetPath, path.join(rootPath, 'link'), symlinkType)
+
+      const filePaths = await getFilePaths({
+        globPattern: '**/*.sh',
+        rootPath,
+        maxItems: 100,
+      })
+
+      expect(relativePaths(filePaths, rootPath)).toEqual(['link/linked.sh'])
+    } finally {
+      fs.rmSync(targetPath, { recursive: true, force: true })
+    }
+  })
+
+  it('does not follow cyclic symbolic links', async () => {
+    fs.writeFileSync(path.join(rootPath, 'script.sh'), '')
+
+    const loopPath = path.join(rootPath, 'loop')
+    fs.symlinkSync(rootPath, loopPath, symlinkType)
+
+    try {
+      const filePaths = await getFilePaths({
+        globPattern: '**/*.sh',
+        rootPath,
+        maxItems: 100,
+      })
+
+      expect(relativePaths(filePaths, rootPath)).toEqual(['script.sh'])
+    } finally {
+      fs.unlinkSync(loopPath)
+    }
+  })
+
+  it('stops after the maximum number of files', async () => {
+    for (let i = 0; i < 10; i++) {
+      fs.writeFileSync(path.join(rootPath, `script-${i}.sh`), '')
+    }
+
+    const filePaths = await getFilePaths({
+      globPattern: '**/*.sh',
+      rootPath,
+      maxItems: 3,
+    })
+
+    expect(filePaths).toHaveLength(3)
+  })
+})

--- a/server/src/util/__tests__/fs.test.ts
+++ b/server/src/util/__tests__/fs.test.ts
@@ -58,6 +58,31 @@ describe('getFilePaths', () => {
     }
   })
 
+  it('follows several symbolic links to the same directory', async () => {
+    const targetPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bash-language-server-fs-target-'),
+    )
+
+    try {
+      fs.writeFileSync(path.join(targetPath, 'shared.sh'), '')
+      fs.symlinkSync(targetPath, path.join(rootPath, 'a'), symlinkType)
+      fs.symlinkSync(targetPath, path.join(rootPath, 'b'), symlinkType)
+
+      const filePaths = await getFilePaths({
+        globPattern: '{a,b}/**/*.sh',
+        rootPath,
+        maxItems: 100,
+      })
+
+      expect(relativePaths(filePaths, rootPath).sort()).toEqual([
+        'a/shared.sh',
+        'b/shared.sh',
+      ])
+    } finally {
+      fs.rmSync(targetPath, { recursive: true, force: true })
+    }
+  })
+
   it('does not follow cyclic symbolic links', async () => {
     fs.writeFileSync(path.join(rootPath, 'script.sh'), '')
 
@@ -72,6 +97,26 @@ describe('getFilePaths', () => {
       })
 
       expect(relativePaths(filePaths, rootPath)).toEqual(['script.sh'])
+    } finally {
+      fs.unlinkSync(loopPath)
+    }
+  })
+
+  it('does not follow cyclic symbolic links to an ancestor', async () => {
+    fs.mkdirSync(path.join(rootPath, 'nested'))
+    fs.writeFileSync(path.join(rootPath, 'nested', 'nested.sh'), '')
+
+    const loopPath = path.join(rootPath, 'nested', 'loop')
+    fs.symlinkSync(rootPath, loopPath, symlinkType)
+
+    try {
+      const filePaths = await getFilePaths({
+        globPattern: '**/*.sh',
+        rootPath,
+        maxItems: 100,
+      })
+
+      expect(relativePaths(filePaths, rootPath)).toEqual(['nested/nested.sh'])
     } finally {
       fs.unlinkSync(loopPath)
     }

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
+import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import * as fastGlob from 'fast-glob'
@@ -13,25 +14,40 @@ export function untildify(pathWithTilde: string): string {
 }
 
 /**
- * Create a file system adapter for `fast-glob` that reads a directory only
- * once, even when it is reachable through multiple (symbolic) links.
+ * Create a file system adapter for `fast-glob` that stops walking a directory
+ * when it links back to one of its own ancestors.
  *
  * `fast-glob` follows symbolic links, so a cyclic symbolic link makes it walk
  * the same directory over and over again until the process runs out of memory.
- * Reading every directory by its real path only once breaks such cycles while
- * keeping symbolic links working.
+ * A directory is only skipped when its real path is the real path of one of
+ * its ancestors, so symbolic links in general, including several links to the
+ * same directory, keep working.
  */
 function createCycleSafeFileSystemAdapter(
-  readRealPaths: Set<string>,
+  realPaths: Map<string, string>,
 ): Partial<fastGlob.FileSystemAdapter> {
-  const isFirstReadOf = (realPath: string): boolean => {
-    if (readRealPaths.has(realPath)) {
-      return false
+  const isAncestorCycle = (directoryPath: string, realPath: string): boolean => {
+    let currentPath = directoryPath
+    let parentPath = path.dirname(currentPath)
+
+    while (parentPath !== currentPath) {
+      if (realPaths.get(parentPath) === realPath) {
+        return true
+      }
+
+      currentPath = parentPath
+      parentPath = path.dirname(currentPath)
     }
 
-    readRealPaths.add(realPath)
+    return false
+  }
 
-    return true
+  const readDirectory = (directoryPath: string, realPath: string): boolean => {
+    const isCycle = isAncestorCycle(directoryPath, realPath)
+
+    realPaths.set(directoryPath, realPath)
+
+    return !isCycle
   }
 
   return {
@@ -41,7 +57,7 @@ function createCycleSafeFileSystemAdapter(
       const done = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback
 
       fs.realpath(directoryPath, (realPathError, realPath) => {
-        if (realPathError == null && !isFirstReadOf(realPath)) {
+        if (realPathError == null && !readDirectory(directoryPath, realPath)) {
           done(null, [])
           return
         }
@@ -55,7 +71,7 @@ function createCycleSafeFileSystemAdapter(
     },
     readdirSync: (directoryPath: string, options?: any) => {
       try {
-        if (!isFirstReadOf(fs.realpathSync(directoryPath))) {
+        if (!readDirectory(directoryPath, fs.realpathSync(directoryPath))) {
           return []
         }
       } catch {
@@ -87,7 +103,7 @@ export async function getFilePaths({
     onlyFiles: true,
     cwd: rootPath,
     followSymbolicLinks: true,
-    fs: createCycleSafeFileSystemAdapter(new Set<string>()),
+    fs: createCycleSafeFileSystemAdapter(new Map<string, string>()),
     suppressErrors: true,
   })
 

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs'
 import * as os from 'node:os'
 import { fileURLToPath } from 'node:url'
 
@@ -9,6 +10,63 @@ export function untildify(pathWithTilde: string): string {
   return homeDirectory
     ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
     : pathWithTilde
+}
+
+/**
+ * Create a file system adapter for `fast-glob` that reads a directory only
+ * once, even when it is reachable through multiple (symbolic) links.
+ *
+ * `fast-glob` follows symbolic links, so a cyclic symbolic link makes it walk
+ * the same directory over and over again until the process runs out of memory.
+ * Reading every directory by its real path only once breaks such cycles while
+ * keeping symbolic links working.
+ */
+function createCycleSafeFileSystemAdapter(
+  readRealPaths: Set<string>,
+): Partial<fastGlob.FileSystemAdapter> {
+  const isFirstReadOf = (realPath: string): boolean => {
+    if (readRealPaths.has(realPath)) {
+      return false
+    }
+
+    readRealPaths.add(realPath)
+
+    return true
+  }
+
+  return {
+    readdir: (directoryPath: string, optionsOrCallback: any, callback?: any) => {
+      const options =
+        typeof optionsOrCallback === 'function' ? undefined : optionsOrCallback
+      const done = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback
+
+      fs.realpath(directoryPath, (realPathError, realPath) => {
+        if (realPathError == null && !isFirstReadOf(realPath)) {
+          done(null, [])
+          return
+        }
+
+        if (options == null) {
+          fs.readdir(directoryPath, done)
+        } else {
+          fs.readdir(directoryPath, options, done)
+        }
+      })
+    },
+    readdirSync: (directoryPath: string, options?: any) => {
+      try {
+        if (!isFirstReadOf(fs.realpathSync(directoryPath))) {
+          return []
+        }
+      } catch {
+        // fall through and let `readdirSync` report the error
+      }
+
+      return options == null
+        ? fs.readdirSync(directoryPath)
+        : fs.readdirSync(directoryPath, options)
+    },
+  } as Partial<fastGlob.FileSystemAdapter>
 }
 
 export async function getFilePaths({
@@ -29,6 +87,7 @@ export async function getFilePaths({
     onlyFiles: true,
     cwd: rootPath,
     followSymbolicLinks: true,
+    fs: createCycleSafeFileSystemAdapter(new Set<string>()),
     suppressErrors: true,
   })
 

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -17,8 +17,12 @@ export function untildify(pathWithTilde: string): string {
  * Create a file system adapter for `fast-glob` that stops walking a directory
  * when it links back to one of its own ancestors.
  *
- * `fast-glob` follows symbolic links, so a cyclic symbolic link makes it walk
- * the same directory over and over again until the process runs out of memory.
+ * `fast-glob` follows symbolic links by default and, like `node-glob`, walks a
+ * cyclic symbolic link forever until the process runs out of memory. Upstream
+ * tracks this as a known limitation with no fix, and the suggested workarounds
+ * (`followSymbolicLinks: false` or a `deep` limit) either drop symlink support
+ * or truncate deep trees — see https://github.com/mrmlnc/fast-glob/issues/74.
+ *
  * A directory is only skipped when its real path is the real path of one of
  * its ancestors, so symbolic links in general, including several links to the
  * same directory, keep working.


### PR DESCRIPTION
### Summary

`fast-glob` follows symbolic links while walking the workspace (`followSymbolicLinks: true`). A repository that contains a cyclic symbolic link (for example `fwupd`'s `src/tests/sys`) therefore makes the server walk the same directory over and over again until Node runs out of memory:

```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

This adds a `fast-glob` file system adapter that records the real path of every directory that is read and returns an empty directory when the same real path is encountered again. Symbolic links keep working, cycles are broken.

### Related issues

fixes #1235

### What changed

- `server/src/util/fs.ts`: `getFilePaths` now passes a cycle-safe `fs` adapter to `fast-glob`.
- `server/src/util/__tests__/fs.test.ts`: new tests for glob matching, following symbolic links, cyclic symbolic links and the `maxItems` limit.

### Verification

- `pnpm exec tsc -b` passes.
- `pnpm exec jest --runInBand server/src/util/__tests__/fs.test.ts`: 4/4 pass.
- Without the fix, the `does not follow cyclic symbolic links` test fails with paths such as `loop/loop/loop/.../script.sh`, which is exactly the runaway behaviour from the issue.
- `pnpm exec eslint server/src/util/fs.ts server/src/util/__tests__/fs.test.ts` passes.
- Full suite: 142 passed (4 more than the 138 passed on a clean checkout). The 7 failing suites (`server.test.ts`, `analyzer.test.ts`, `sourcing`, `sh`, `shfmt`, `executables`, `shellcheck`) fail identically on a clean checkout in this environment, so they are unrelated to this change.

### Notes

- Directories reachable through more than one link are now read only once, which also avoids doing the same work twice.
- The test creates the cycle with a junction on Windows (no administrator rights required) and a directory symlink on other platforms.
